### PR TITLE
[invite] 초대장 공유하기 뷰 연결 및 Api 통신 구현

### DIFF
--- a/src/components/shareModule/InviteModal.tsx
+++ b/src/components/shareModule/InviteModal.tsx
@@ -2,14 +2,19 @@ import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import { icKakao, icPaste } from '@src/assets/icons';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { shareKakao } from './ShareKakao';
 import { useCopyLink, setKakao } from './ShareModule';
 
-function InviteModal() {
-  const [teamCode] = useState<string>('ttime');
-  const [teamLink] = useState<string>(`http://192.168.0.134:3000/${teamCode}`);
+interface InviteType {
+  setModalState: Dispatch<SetStateAction<boolean>>;
+  teamCode: string;
+  teamName: string;
+}
+
+function InviteModal({ setModalState, teamCode, teamName }: InviteType) {
+  const [teamLink] = useState<string>(`http://192.168.0.134:3000/join/${teamCode}`);
 
   useEffect(() => {
     setKakao();
@@ -31,12 +36,12 @@ function InviteModal() {
                 <StButtonText>초대링크 복사하기</StButtonText>
               </StCopyButton>
             </CopyToClipboard>
-            <StKakaoButton onClick={() => shareKakao(teamLink, teamCode, '개인결과')}>
+            <StKakaoButton onClick={() => shareKakao(teamLink, teamName, '개인결과')}>
               <StButtonIcon src={icKakao.src} />
               <StButtonText>카카오톡 공유하기</StButtonText>
             </StKakaoButton>
           </StButtonContainer>
-          <StFooter>닫기</StFooter>
+          <StFooter onClick={() => setModalState(false)}>닫기</StFooter>
         </StModal>
       </StBackground>
     </StInviteModal>
@@ -48,6 +53,7 @@ export default InviteModal;
 const StInviteModal = styled.div`
   width: 100vw;
   touch-action: none;
+  z-index: 3;
 `;
 const StBackground = styled.main`
   display: flex;
@@ -85,12 +91,15 @@ const StInviteArticle = styled.article`
 `;
 const StArticleTitle = styled.div`
   width: 22.6rem;
+  text-align: center;
   ${FONT_STYLES.PRETENDARD_B_14};
 `;
 const StArticleLink = styled.div`
-  width: 22.6rem;
+  width: 100%;
+  text-align: center;
   margin-top: 0.4rem;
   ${FONT_STYLES.NEXON_R_14};
+  font-size: 1.3rem;
 `;
 const StButtonContainer = styled.div`
   margin: 4rem 2.3rem 4rem 2.3rem;

--- a/src/pages/invite/[teamCode].tsx
+++ b/src/pages/invite/[teamCode].tsx
@@ -9,13 +9,18 @@ import ImageDiv from '@src/components/common/ImageDiv';
 import BottomButton from '@src/components/common/BottomButton';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import InviteModal from '@src/components/shareModule/InviteModal';
 
 function ConfirmInvite() {
   const router = useRouter();
   useManageScroll();
   const [isConfirmed, setIsconfirmed] = useState<boolean>(false);
+  const [modalState, setModalState] = useState<boolean>(false);
   return (
     <StConfirmInvite>
+      {modalState ? (
+        <InviteModal teamName={router.query.teamName} setModalState={setModalState} teamCode={router.query.teamCode} />
+      ) : null}
       <TextTop text={'초대장 만들기'} />
       <StInvitationContainer>
         <ImageDiv src={imgInvitation} alt="초대장이미지" className="invitationImg"></ImageDiv>
@@ -31,7 +36,7 @@ function ConfirmInvite() {
         </StListContainer>
       </StInvitationContainer>
       {isConfirmed ? (
-        <StBtnWrapper>
+        <StBtnWrapper onClick={() => setModalState(true)}>
           <BottomButton width={28.2} color={COLOR.BLUE_1} text={'초대장 공유하기'} />
         </StBtnWrapper>
       ) : (

--- a/src/pages/invite/[teamCode].tsx
+++ b/src/pages/invite/[teamCode].tsx
@@ -19,8 +19,12 @@ function ConfirmInvite() {
   const [modalState, setModalState] = useState<boolean>(false);
   return (
     <StConfirmInvite>
-      {modalState ? (
-        <InviteModal teamName={router.query.teamName} setModalState={setModalState} teamCode={router.query.teamCode} />
+      {modalState && router.query.teamName ? (
+        <InviteModal
+          teamName={String(router.query.teamName)}
+          setModalState={setModalState}
+          teamCode={String(router.query.teamCode)}
+        />
       ) : null}
       <TextTop text={'초대장 만들기'} />
       <StInvitationContainer>

--- a/src/pages/invite/[teamCode].tsx
+++ b/src/pages/invite/[teamCode].tsx
@@ -10,6 +10,7 @@ import BottomButton from '@src/components/common/BottomButton';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import InviteModal from '@src/components/shareModule/InviteModal';
+import Link from 'next/link';
 
 function ConfirmInvite() {
   const router = useRouter();
@@ -42,9 +43,17 @@ function ConfirmInvite() {
       ) : (
         <StMessage>위 정보로 티타임 초대장을 만드시겠습니까?</StMessage>
       )}
-      <StConfirmBtn onClick={() => setIsconfirmed(true)}>
-        <BottomButton width={28.2} color={COLOR.ORANGE_1} text={isConfirmed ? '티타임 참여하기' : '확인'} />
-      </StConfirmBtn>
+      {!isConfirmed ? (
+        <StConfirmBtn onClick={() => setIsconfirmed(true)}>
+          <BottomButton width={28.2} color={COLOR.ORANGE_1} text={isConfirmed ? '티타임 참여하기' : '확인'} />
+        </StConfirmBtn>
+      ) : (
+        <Link href={`/join/${router.query.teamCode}`}>
+          <StConfirmBtn>
+            <BottomButton width={28.2} color={COLOR.ORANGE_1} text={isConfirmed ? '티타임 참여하기' : '확인'} />
+          </StConfirmBtn>
+        </Link>
+      )}
     </StConfirmInvite>
   );
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #63 

## 📋 구현 기능 명세
- [x] 전반부 flow 전체 완성
- [x] 초대장 공유하기 api 통신 완료
- [x] 초대장 공유하기 데이터 flow 구현

## 📌 PR Point
- 서연이의 invite와 다른부분들을 합치면서, 전반부 flow를 전체 완성하였어요. 
- 초대장 공유하기의 ClipBoard 복사와 카카오 공유하기 복사의 올바른 데이터를 전송하도록 구현하였어요
- join까지의 전반적 흐름을 점검하고 완료하였어요

## 📸 결과물 스크린샷