### PR TITLE
[feat] 팀정보 가져오기 api 연결

### DIFF
--- a/src/pages/join/[teamCode].tsx
+++ b/src/pages/join/[teamCode].tsx
@@ -12,7 +12,7 @@ import { useMutation } from 'react-query';
 import { TeamData } from '@src/mocks/types';
 import useManageScroll from '@src/hooks/UseManageScroll';
 import { useQuery } from 'react-query';
-import { getCompleted } from '@src/services';
+import { getTeamData } from '@src/services';
 
 interface IApiError {
   response: {
@@ -30,7 +30,7 @@ function Join() {
   const teamCode = Number(router.asPath.split('/')[2]);
   const [nickname, setNickname] = useState<string>('');
 
-  const { data } = useQuery('teamData', () => getCompleted(teamCode), {
+  const { data } = useQuery('teamData', () => getTeamData(teamCode), {
     enabled: !!teamCode,
   });
 
@@ -86,7 +86,7 @@ function Join() {
           <StInviteComment>에 초대합니다</StInviteComment>
         </StRowContainer>
         <StListContainer>
-          <StList>총 {data?.totalNumber}명</StList>
+          <StList>총 {data?.teamMember}명</StList>
           <StList>질문 개수: 12개</StList>
           <StList>예상 소요시간: 약 10분 이내</StList>
         </StListContainer>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,6 +5,11 @@ export const test = async (body: object) => {
   await api.post({ url: `/api/team/729262811`, data: body });
 };
 
+export const getTeamData = async (teamId: number) => {
+  const { data } = await api.get({ url: `/api/team/${teamId}` });
+  return data;
+};
+
 export const getTeamInfo = async (body: object) => {
   const { data } = await api.post({ url: `/api/team`, data: body });
   return data;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #69 

## 📋 구현 기능 명세
- [x] 팀정보 가져오기 api를 연결했습니다

## 📌 PR Point
- services/index.ts 에 api 추가
```javascript
export const getTeamData = async (teamId: number) => {
  const { data } = await api.get({ url: `/api/team/${teamId}` });
  return data;
};
```

- join 페이지에서 활용
```javascript
  const { data } = useQuery('teamData', () => getTeamData(teamCode), {
    enabled: !!teamCode,
  });
```


## 📸 결과물 스크린샷
<img width="319" alt="image" src="https://user-images.githubusercontent.com/87795291/211750567-a2c4df1e-d17f-4017-94b8-ebfa2dfc4ce7.png">
