### PR TITLE
[myResult] LocalStorage 조건부 로직 추가

### DIFF
--- a/src/components/myResult/ResultGraph.tsx
+++ b/src/components/myResult/ResultGraph.tsx
@@ -14,7 +14,7 @@ interface graphWidth {
 function ResultGraph({ result }: graphData) {
   const { query, isReady } = useRouter();
 
-  if (isReady && String(query.teamId != 'noTeam')) {
+  if (isReady && String(query.teamId) !== 'noTeam') {
     localStorage.setItem('userId', String(query.userId));
   }
 

--- a/src/components/myResult/ResultGraph.tsx
+++ b/src/components/myResult/ResultGraph.tsx
@@ -12,8 +12,11 @@ interface graphWidth {
 }
 
 function ResultGraph({ result }: graphData) {
-  const router = useRouter();
-  localStorage.setItem('userId', router.asPath.split('/')[3]);
+  const { query, isReady } = useRouter();
+
+  if (isReady && String(query.teamId != 'noTeam')) {
+    localStorage.setItem('userId', String(query.userId));
+  }
 
   return (
     <>

--- a/src/components/teamResult/UnfinishedResult.tsx
+++ b/src/components/teamResult/UnfinishedResult.tsx
@@ -24,9 +24,12 @@ function UnfinishedResult({ completeData }: completeDataType) {
   const date = new Date();
   const year = date.getFullYear();
   let month: string | number = date.getMonth() + 1;
-  const day: string | number = date.getDate();
+  let day: string | number = date.getDate();
   if (month < 10) {
     month = '0' + month;
+  }
+  if (day < 10) {
+    day = '0' + day;
   }
 
   return (

--- a/src/components/teamResult/UnfinishedResult.tsx
+++ b/src/components/teamResult/UnfinishedResult.tsx
@@ -19,8 +19,8 @@ interface completeDataType {
 
 function UnfinishedResult({ completeData }: completeDataType) {
   const { query } = useRouter();
-  const userId = String(query.userId);
-  const resultLink = `https://t-time.vercel.app/teamResult/noTeam/${userId}`;
+  const teamId = String(query.teamId);
+  const resultLink = `https://t-time.vercel.app/teamResult/${teamId}/noUser`;
   const date = new Date();
   const year = date.getFullYear();
   let month: string | number = date.getMonth() + 1;

--- a/src/components/teamResult/UnfinishedResult.tsx
+++ b/src/components/teamResult/UnfinishedResult.tsx
@@ -18,10 +18,9 @@ interface completeDataType {
 }
 
 function UnfinishedResult({ completeData }: completeDataType) {
-  const router = useRouter();
-  const teamId = Number(router.asPath.split('/')[2]);
-  const userId = router.asPath.split('/')[3];
-  const resultLink = `https://t-time.vercel.app/teamResult/${teamId}/${userId}`;
+  const { query } = useRouter();
+  const userId = String(query.userId);
+  const resultLink = `https://t-time.vercel.app/teamResult/noTeam/${userId}`;
   const date = new Date();
   const year = date.getFullYear();
   let month: string | number = date.getMonth() + 1;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #107

## 📋 구현 기능 명세
- [x] 3차 QA에서 나왔던 내용대로, 공유받은 링크(noTeam)상태로 링크에 입장되었을때, LocalStorage에 UserId가 추가되지 않는 조건부 로직을 추가합니다!


## 📌 PR Point

```javascript
if (isReady && String(query.teamId) !== 'noTeam') {
    localStorage.setItem('userId', String(query.userId));
  }
```
요런식으로, 현재 가져온 teamId가 noTeam일때, localStorage에 저장되지 않도록 수정했습니다!

`const resultLink = https://t-time.vercel.app/teamResult/noTeam/${userId};`
