### PR TITLE
[common] 카카오 링크 복사 썸네일 및 문구 변경

### DIFF
--- a/src/components/common/LogoTop.tsx
+++ b/src/components/common/LogoTop.tsx
@@ -1,11 +1,14 @@
 import styled from 'styled-components';
 import { imgTopLogo } from '@src/assets/images';
 import ImageDiv from '@src/components/common/ImageDiv';
+import Link from 'next/link';
 
 function LogoTop() {
   return (
     <StLogoTop>
-      <ImageDiv src={imgTopLogo} alt="T.time" className="imgTopLogo" fill={true} />
+      <Link href="/">
+        <ImageDiv src={imgTopLogo} alt="T.time" className="imgTopLogo" fill={true} />
+      </Link>
     </StLogoTop>
   );
 }

--- a/src/components/common/SEO.tsx
+++ b/src/components/common/SEO.tsx
@@ -2,20 +2,23 @@ import Head from 'next/head';
 
 interface SEOProps {
   title: string;
+  ogTitle?: string;
   description: string;
+  image?: string;
+  url?: string;
 }
 
-function SEO({ title, description }: SEOProps) {
+function SEO({ title, ogTitle, description, image, url }: SEOProps) {
   return (
     <Head>
       <title>{title}</title>
       <link rel="icon" href="/favicon.ico" />
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="T.time" />
-      <meta property="og:title" content="T.time" />
+      <meta property="og:title" content={ogTitle ?? 'T.time'} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content="/img_thumbnail.png" />
-      <meta property="og:url" content="https://t-time.vercel.app/" />
+      <meta property="og:image" content={image ?? '/img_thumbnail.png'} />
+      <meta property="og:url" content={url ?? '/img_thumbnail.png'} />
       <meta property="og:locale" content="ko_KR" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" id="viewportMeta" />
     </Head>

--- a/src/components/common/SEO.tsx
+++ b/src/components/common/SEO.tsx
@@ -18,7 +18,7 @@ function SEO({ title, ogTitle, description, image, url }: SEOProps) {
       <meta property="og:title" content={ogTitle ?? 'T.time'} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={image ?? '/img_thumbnail.png'} />
-      <meta property="og:url" content={url ?? '/img_thumbnail.png'} />
+      <meta property="og:url" content={url ?? 'https://t-time.vercel.app'} />
       <meta property="og:locale" content="ko_KR" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" id="viewportMeta" />
     </Head>

--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -26,12 +26,16 @@ interface ctxType {
 interface userIdType {
   userId: number;
   teamId: number;
+  myResultData: UserData;
 }
-function MyResult({ userId, teamId }: userIdType) {
+
+function MyResult({ userId, teamId, myResultData }: userIdType) {
   const [resultData, setResultData] = useState<UserData>();
   const [resultCharacter, setResultCharacter] = useState(0);
   const [isVisitor, setIsVisitor] = useState(false);
-  const { data } = useQuery('userData', () => getMyResult(userId));
+  const { data } = useQuery('userData', () => getMyResult(userId), {
+    initialData: myResultData,
+  });
   const [modalState, setModalState] = useState(false);
   const { query, isReady } = useRouter();
   useEffect(() => {
@@ -50,7 +54,13 @@ function MyResult({ userId, teamId }: userIdType) {
 
   return (
     <StmyResultPage>
-      <SEO title="T.time | 팀과 내가 함께 성장하는 시간" description="결과를 확인해보세요!" />
+      <SEO
+        title="T.time | 팀과 내가 함께 성장하는 시간"
+        ogTitle={myResultData.nickname + '님의 T.time 결과를 확인해보세요'}
+        description="개인결과는 링크가 있는 사람만 볼 수 있어요.☕️"
+        image="/img_personalShare.png"
+        url={'https://t-time.vercel.app/myResult/noTeam/' + userId}
+      />
       <LogoTop />
       {resultData ? (
         <StMyResult>
@@ -108,6 +118,13 @@ function MyResult({ userId, teamId }: userIdType) {
   );
 }
 export default MyResult;
+
+export const getServerSideProps = async (ctx: ctxType) => {
+  const userId = parseInt(ctx.query.userId);
+  const teamId = parseInt(ctx.query.teamId);
+  const myResultData = await getMyResult(userId);
+  return { props: { userId, teamId, myResultData } };
+};
 
 const StmyResultPage = styled.div``;
 
@@ -240,9 +257,3 @@ const StCardFooter = styled.footer`
     margin-bottom: 1.2rem;
   }
 `;
-
-export async function getServerSideProps(ctx: ctxType) {
-  const userId = parseInt(ctx.query.userId);
-  const teamId = parseInt(ctx.query.teamId);
-  return { props: { userId, teamId } };
-}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #110 

## 📋 구현 기능 명세
- [x] 동적 메타 태그를 적용
- [x] 상단 로고 이미지 누르면 메인 페이지로 돌아가도록 수정

## 📌 PR Point
- getServerSideProps를 이용하여 메타 태그에 정보가 미리 들어가도록 수정했습니다. 개발 환경에서 확인을 못해서 머지 후 확인해보려고 합니다!
- 로고 버튼을 누르면 메인 페이지로 이동합니다.

## 📸 결과물 스크린샷
<img width="438" alt="스크린샷 2023-02-13 오후 9 46 29" src="https://user-images.githubusercontent.com/99077953/218461297-f9eb5e84-926a-42b8-90f5-d467405426fc.png">