### PR TITLE
[common] 로그인 작업 전 수정 사항 최종 반영

### DIFF
--- a/src/components/teamResult/ResultFrame.tsx
+++ b/src/components/teamResult/ResultFrame.tsx
@@ -33,7 +33,7 @@ const StFrame = styled.div`
   width: 34.6rem;
   height: 100%;
   margin: 2.6rem 0 14.4rem 0;
-  padding: 2.1rem 2.1rem;
+  padding: 2.5rem 2.1rem 2.1rem 2.1rem;
   border-radius: 1.4rem;
   background-color: ${COLOR.IVORY_1};
   box-shadow: 0 0.2rem 1rem rgba(0, 0, 0, 0.1);

--- a/src/components/teamResult/SimpleResult.tsx
+++ b/src/components/teamResult/SimpleResult.tsx
@@ -81,7 +81,7 @@ function SimpleResult({ teamId }: TeamResultProps) {
       <StTeamName>&#39;{teamName}&#39;</StTeamName>
       <StTeamResultText>
         <p>팀</p>
-        <img src={imgCenturyGothicLogo.src} alt="logo" className="logo" />
+        <img src={imgCenturyGothicLogo.src} alt="T.time" className="logo" />
         <p>결과</p>
       </StTeamResultText>
       <StImageContainer>

--- a/src/pages/invite/[teamId].tsx
+++ b/src/pages/invite/[teamId].tsx
@@ -38,13 +38,13 @@ function ConfirmInvite({ teamId, teamName }: ConfirmInviteProps) {
         description="초대장을 열고, 티타임에 입장해보세요.☕️"
         url={'https://t-time.vercel.app/join/' + teamId}
       />
-      {modalState && router.query.teamName ? (
+      {modalState && teamName ? (
         <InviteModal teamName={teamName} setModalState={setModalState} teamId={String(router.query.teamId)} />
       ) : null}
       <TextTop text={'초대장 만들기'} />
       <StInvitationContainer>
         <ImageDiv src={imgInvitation} alt="초대장이미지" className="invitationImg"></ImageDiv>
-        <StTeamName>&apos;{router.query.teamName}&apos;</StTeamName>
+        <StTeamName>&apos;{teamName}&apos;</StTeamName>
         <StRowContainer>
           <ImageDiv src={imgCenturyGothicLogo} alt="T.time_logo" className="imgCenturyGothicLogo" fill></ImageDiv>
           <StInviteComment>에 초대합니다</StInviteComment>

--- a/src/pages/invite/[teamId].tsx
+++ b/src/pages/invite/[teamId].tsx
@@ -13,20 +13,33 @@ import { useRouter } from 'next/router';
 import InviteModal from '@src/components/shareModule/InviteModal';
 import Link from 'next/link';
 
-function ConfirmInvite() {
+interface ctxType {
+  query: {
+    teamId: number;
+    teamName: string;
+  };
+}
+
+interface ConfirmInviteProps {
+  teamId: number;
+  teamName: string;
+}
+
+function ConfirmInvite({ teamId, teamName }: ConfirmInviteProps) {
   const router = useRouter();
   useManageScroll();
   const [isConfirmed, setIsconfirmed] = useState<boolean>(false);
   const [modalState, setModalState] = useState<boolean>(false);
   return (
     <StConfirmInvite>
-      <SEO title="T.time | 팀과 내가 함께 성장하는 시간" description="T.time | 팀과 내가 함께 성장하는 시간" />
+      <SEO
+        title="T.time | 팀과 내가 함께 성장하는 시간"
+        ogTitle={teamName + '팀 초대장이 도착했어요!'}
+        description="초대장을 열고, 티타임에 입장해보세요.☕️"
+        url={'https://t-time.vercel.app/join/' + teamId}
+      />
       {modalState && router.query.teamName ? (
-        <InviteModal
-          teamName={String(router.query.teamName)}
-          setModalState={setModalState}
-          teamId={String(router.query.teamId)}
-        />
+        <InviteModal teamName={teamName} setModalState={setModalState} teamId={String(router.query.teamId)} />
       ) : null}
       <TextTop text={'초대장 만들기'} />
       <StInvitationContainer>
@@ -64,6 +77,12 @@ function ConfirmInvite() {
   );
 }
 export default ConfirmInvite;
+
+export const getServerSideProps = async (ctx: ctxType) => {
+  const teamId = ctx.query.teamId;
+  const teamName = ctx.query.teamName;
+  return { props: { teamId, teamName } };
+};
 
 const StConfirmInvite = styled.div`
   display: flex;

--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -17,6 +17,7 @@ import BottomBtnContainer from '@src/components/myResult/BottomBtnContainer';
 import LoadingView from '@src/components/common/LoadingView';
 import MyResultModal from '@src/components/shareModule/MyResultModal';
 import { useRouter } from 'next/router';
+import { imgCenturyGothicLogo } from '@src/assets/images';
 interface ctxType {
   query: {
     userId: string;
@@ -52,6 +53,10 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
     }
   }, [isReady]);
 
+  const handleDate = (date: string) => {
+    return date && date.replaceAll('-', '.');
+  };
+
   return (
     <StmyResultPage>
       <SEO
@@ -69,13 +74,17 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
           )}
           <StResultCard>
             <StInfoContainer>
-              <p className="date">{resultData.date}</p>
+              <p className="date">{handleDate(resultData.date)}</p>
               <p className="teamName">&#39;{resultData.teamName}&#39;</p>
               <div className="resultTitle">
                 <p>
                   <span className="userName">{resultData.nickname}</span> 님의
                 </p>
-                <p>개인 T.time 결과</p>
+                <StTeamResultText>
+                  <p>개인</p>
+                  <img src={imgCenturyGothicLogo.src} alt="T.time" className="logo" />
+                  <p>결과</p>
+                </StTeamResultText>
               </div>
             </StInfoContainer>
             <StUserImage src={RESULT_MESSAGE[resultCharacter]?.imageUrl}></StUserImage>
@@ -152,15 +161,18 @@ const StInfoContainer = styled.div`
   .date {
     ${FONT_STYLES.PRETENDARD_M_12};
     color: ${COLOR.GRAY_9E};
+    line-height: 1.432rem;
   }
   .teamName {
     ${FONT_STYLES.NEXON_B_16};
     color: ${COLOR.GRAY_7E};
     margin: 0.8rem 0 1.2rem 0;
+    line-height: 2.24rem;
   }
   .resultTitle {
     ${FONT_STYLES.NEXON_B_22};
     color: ${COLOR.BLACK};
+    line-height: 2.64rem;
   }
   .resultTitle p {
     margin-bottom: 0.5rem;
@@ -168,6 +180,18 @@ const StInfoContainer = styled.div`
   }
   .userName {
     color: ${COLOR.BLUE_TEXT};
+  }
+`;
+const StTeamResultText = styled.div`
+  display: flex;
+  color: ${COLOR.BLACK};
+  ${FONT_STYLES.NEXON_B_22}
+  line-height: 2.64rem;
+  .logo {
+    position: relative;
+    width: 7.2rem;
+    height: 2.4rem;
+    margin: 0 0.4rem;
   }
 `;
 const StDotsImage = styled.div`

--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -165,8 +165,8 @@ const StInfoContainer = styled.div`
   }
   .teamName {
     ${FONT_STYLES.NEXON_B_16};
-    color: ${COLOR.GRAY_7E};
     margin: 0.8rem 0 1.2rem 0;
+    color: ${COLOR.GRAY_7E};
     line-height: 2.24rem;
   }
   .resultTitle {

--- a/src/pages/teamResult/[teamId]/[userId].tsx
+++ b/src/pages/teamResult/[teamId]/[userId].tsx
@@ -60,7 +60,7 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
       />
       <LogoTop />
       {completeData ? (
-        completeData?.completed && !isLoading ? (
+        completeData.completed && !isLoading ? (
           <>
             {modalState ? <TeamModal teamName={data?.teamName} setModalState={setModalState} /> : <></>}
             <ResultFrame teamId={teamId} />
@@ -68,7 +68,7 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
             <StBackground />
           </>
         ) : (
-          <UnfinishedResult completeData={data} />
+          <UnfinishedResult completeData={completeData} />
         )
       ) : (
         <LoadingView />


### PR DESCRIPTION
## 🚩 관련 이슈
- close #112 

## 📋 구현 기능 명세
- [x] 초대장 링크 동적 메타 태그 적용
- [x] 상단 로고 클릭 시 이동
- [x] 날짜 형식 통일

## 📌 PR Point
### 1. 동적 메타 태그 적용
🐛 링크를 공유했을 때 미리 나오는 정보를 설정하기 위해서는 **메타 태그를 수정**해야 합니다. 메타 태그의 경우 정적 데이터가 적용되기 때문에 서버 통신을 통해 받는 `팀 이름`과 `닉네임`을 넣어줄 수 없는 문제가 있었습니다. 

👩‍🔧 `getServerSideProps` 에서 서버 통신을 한 데이터를 useQuery의 initialData로 넘겨주었습니다. initialData로 넘겨받은 데이터를 SEO 컴포넌트의 props로 넘겨주었습니다. 해당 변경사항은 #111 에서 확인할 수 있습니다.

- getServerSideProps
```
export const getServerSideProps = async (ctx: ctxType) => {
  const teamId = parseInt(ctx.query.teamId);
  const teamData = await getTeamData(teamId);
  return { props: { teamId, teamData } };
};
```

- 클라이언트 코드 / **initialData**는 SSR로 불러온 응답을 **ReactQuery 기본값**으로 넣어주는 방법
```
  const { data } = useQuery('getTeamData', () => getTeamData(teamId), {
    initialData: teamData,
  });
```
### 2. 상단 로고 클릭 시 이동
`Link` 태그를 이용해 구현했습니다. 이 또한 이전 PR(#111) 에서 확인할 수 있습니다.
### 3. 날짜 형식 통일 및 내 결과 페이지 디자인 디테일 수정

## 📸 결과물 스크린샷
### 1.
슬랙
<img src="https://user-images.githubusercontent.com/99077953/218691884-82a7a585-e60a-4768-baa7-6e145966f721.jpg" width="300">
카카오톡
<img src="https://user-images.githubusercontent.com/99077953/218691894-34bcfe05-56e4-4e00-9e3f-1bdc9d5ead84.jpg" width="300">
### 3. 
왼쪽이 전, 오른쪽이 후 (*변경사항: 날짜 형식, 글씨체 line-height, T.time 로고 이미지로 수정)
<img width="952" alt="스크린샷 2023-02-14 오후 6 16 07" src="https://user-images.githubusercontent.com/99077953/218691585-32b8b0f2-e4fc-48c6-9c2d-77414bc1d592.png">
