### PR TITLE
[common] 구글 소셜 로그인 및 회원가입 실서버 연결

### DIFF
--- a/src/components/common/GoogleLoginButton.tsx
+++ b/src/components/common/GoogleLoginButton.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useSetRecoilState } from 'recoil';
 import { prevPathState } from '@src/atoms/login';
 import { useRouter } from 'next/router';
+import { DOMAIN } from '@src/constants/domain';
 
 function GoogleLoginButton() {
   const setPrevPath = useSetRecoilState(prevPathState);
@@ -15,7 +16,8 @@ function GoogleLoginButton() {
     'https://accounts.google.com/o/oauth2/auth?client_id=' +
     process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID +
     '&redirect_uri=' +
-    process.env.NEXT_PUBLIC_REDIRECT_URL +
+    DOMAIN +
+    '/auth/google' +
     '&response_type=token&' +
     '&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile';
   const getCurrentPath = () => {
@@ -35,6 +37,8 @@ function GoogleLoginButton() {
 export default GoogleLoginButton;
 
 const StGoogleLoginButton = styled.button`
+  position: relative;
+  top: 80rem;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/common/SEO.tsx
+++ b/src/components/common/SEO.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { DOMAIN } from '@src/constants/domain';
 
 interface SEOProps {
   title: string;
@@ -18,7 +19,7 @@ function SEO({ title, ogTitle, description, image, url }: SEOProps) {
       <meta property="og:title" content={ogTitle ?? 'T.time'} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={image ?? '/img_thumbnail.png'} />
-      <meta property="og:url" content={url ?? 'https://t-time.vercel.app'} />
+      <meta property="og:url" content={url ?? DOMAIN} />
       <meta property="og:locale" content="ko_KR" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" id="viewportMeta" />
     </Head>

--- a/src/components/shareModule/InviteModal.tsx
+++ b/src/components/shareModule/InviteModal.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { shareKakao } from './ShareKakao';
 import { useCopyLink, setKakao } from './ShareModule';
+import { DOMAIN } from '@src/constants/domain';
 
 interface InviteType {
   setModalState: Dispatch<SetStateAction<boolean>>;
@@ -15,7 +16,7 @@ interface InviteType {
 }
 
 function InviteModal({ setModalState, teamId, teamName }: InviteType) {
-  const [teamLink] = useState<string>(`https://t-time.vercel.app/join/${teamId}`);
+  const [teamLink] = useState<string>(`${DOMAIN}/join/${teamId}`);
 
   useEffect(() => {
     setKakao();

--- a/src/components/shareModule/MyResultModal.tsx
+++ b/src/components/shareModule/MyResultModal.tsx
@@ -8,13 +8,14 @@ import { useState, useEffect } from 'react';
 import { shareKakao } from './ShareKakao';
 import { useCopyLink, setKakao } from './ShareModule';
 import { Dispatch, SetStateAction } from 'react';
+import { DOMAIN } from '@src/constants/domain';
 interface sharePropsType {
   setModalState: Dispatch<SetStateAction<boolean>>;
   userName: string;
   userId: string;
 }
 function MyResultModal({ setModalState, userName, userId }: sharePropsType) {
-  const [myResultLink] = useState<string>(`https://t-time.vercel.app/myResult/noTeam/${userId}`);
+  const [myResultLink] = useState<string>(`${DOMAIN}/myResult/noTeam/${userId}`);
   useEffect(() => {
     setKakao();
   }, []);

--- a/src/components/shareModule/TeamModal.tsx
+++ b/src/components/shareModule/TeamModal.tsx
@@ -9,6 +9,7 @@ import { shareKakao } from './ShareKakao';
 import { useCopyLink, setKakao } from './ShareModule';
 import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction } from 'react';
+import { DOMAIN } from '@src/constants/domain';
 interface sharePropsType {
   setModalState: Dispatch<SetStateAction<boolean>>;
   teamName: string;
@@ -16,7 +17,7 @@ interface sharePropsType {
 function TeamModal({ setModalState, teamName }: sharePropsType) {
   const router = useRouter();
   const teamId = router.asPath.split('/')[2];
-  const [teamLink] = useState<string>(`https://t-time.vercel.app/teamResult/${teamId}/noUser`);
+  const [teamLink] = useState<string>(`${DOMAIN}/teamResult/${teamId}/noUser`);
   useEffect(() => {
     setKakao();
   }, []);

--- a/src/components/teamResult/DetailResult.tsx
+++ b/src/components/teamResult/DetailResult.tsx
@@ -49,6 +49,14 @@ function DetailResult({ teamId }: TeamResultProps) {
     return sortedList;
   };
 
+  const handleNickname = (nickname: string) => {
+    if (nickname.length > 4) {
+      return nickname.slice(0, 3) + '...';
+    } else {
+      return nickname;
+    }
+  };
+
   const handleCategoryEmoticon = (category: string) => {
     switch (category) {
       case CATEGORY_LIST[0]:
@@ -88,7 +96,7 @@ function DetailResult({ teamId }: TeamResultProps) {
               {handleSorting(questionOneList).map(({ grade, nickname, answer }, index) => (
                 <StAnswerItem key={index}>
                   <StName maxStyle={grade === 5} minStyle={grade === 1}>
-                    {nickname}
+                    {handleNickname(nickname)}
                   </StName>
                   <StAnswer>
                     <span>{grade}</span>

--- a/src/components/teamResult/UnfinishedResult.tsx
+++ b/src/components/teamResult/UnfinishedResult.tsx
@@ -7,6 +7,7 @@ import BottomButton from '../common/BottomButton';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useCopyLink } from '../shareModule/ShareModule';
 import { useRouter } from 'next/router';
+import { DOMAIN } from '@src/constants/domain';
 
 interface completeDataType {
   completeData: {
@@ -20,7 +21,7 @@ interface completeDataType {
 function UnfinishedResult({ completeData }: completeDataType) {
   const { query } = useRouter();
   const teamId = String(query.teamId);
-  const resultLink = `https://t-time.vercel.app/teamResult/${teamId}/noUser`;
+  const resultLink = `${DOMAIN}/teamResult/${teamId}/noUser`;
   const date = new Date();
   const year = date.getFullYear();
   let month: string | number = date.getMonth() + 1;

--- a/src/constants/domain.ts
+++ b/src/constants/domain.ts
@@ -1,0 +1,2 @@
+const isProduction = process.env.NODE_ENV === 'production';
+export const DOMAIN = isProduction ? 'https://t-time.vercel.app/' : 'http://localhost:3000';

--- a/src/constants/domain.ts
+++ b/src/constants/domain.ts
@@ -1,2 +1,2 @@
 const isProduction = process.env.NODE_ENV === 'production';
-export const DOMAIN = isProduction ? 'https://t-time.vercel.app/' : 'http://localhost:3000';
+export const DOMAIN = isProduction ? 'https://t-time.vercel.app' : 'http://localhost:3000';

--- a/src/pages/auth/google.tsx
+++ b/src/pages/auth/google.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { prevPathState } from '@src/atoms/login';
 import { requestLogin } from '@src/services';
-import { useMutation } from 'react-query';
+import { useQuery } from 'react-query';
 import { useEffect } from 'react';
 
 function Google() {
@@ -11,7 +11,7 @@ function Google() {
   const url = router.asPath;
   const code = url?.split('#access_token=')[1]?.split('&')[0];
 
-  const { data, mutate } = useMutation(requestLogin, {
+  const { data } = useQuery('requestLogin', () => requestLogin({ social: 'GOOGLE', token: code }), {
     onSuccess: () => {
       if (prevPath === '/organizerOnboarding') {
         router.push('/');
@@ -23,11 +23,8 @@ function Google() {
       console.error('로그인 요청이 실패했습니다.');
       router.push(prevPath);
     },
+    enabled: !!code,
   });
-
-  useEffect(() => {
-    mutate({ social: 'GOOGLE', token: code });
-  }, []);
 
   useEffect(() => {
     localStorage.setItem('accessToken', data?.accessToken);

--- a/src/pages/auth/google.tsx
+++ b/src/pages/auth/google.tsx
@@ -6,11 +6,12 @@ import { useMutation } from 'react-query';
 import { useEffect } from 'react';
 
 function Google() {
-  const router = useRouter();
   const prevPath = useRecoilValue(prevPathState);
+  const router = useRouter();
   const url = router.asPath;
   const code = url?.split('#access_token=')[1]?.split('&')[0];
-  const { mutate } = useMutation(requestLogin, {
+
+  const { data, mutate } = useMutation(requestLogin, {
     onSuccess: () => {
       if (prevPath === '/organizerOnboarding') {
         router.push('/');
@@ -23,9 +24,14 @@ function Google() {
       router.push(prevPath);
     },
   });
+
   useEffect(() => {
     mutate({ social: 'GOOGLE', token: code });
-  }, [code, mutate]);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('accessToken', data?.accessToken);
+  }, [data]);
   return <></>;
 }
 

--- a/src/pages/auth/google.tsx
+++ b/src/pages/auth/google.tsx
@@ -16,7 +16,7 @@ function Google() {
       if (prevPath === '/organizerOnboarding') {
         router.push('/');
       } else {
-        router.push(prevPath);
+        router.push('/participantOnboarding');
       }
     },
     onError: () => {
@@ -32,6 +32,7 @@ function Google() {
   useEffect(() => {
     localStorage.setItem('accessToken', data?.accessToken);
   }, [data]);
+
   return <></>;
 }
 

--- a/src/pages/auth/google.tsx
+++ b/src/pages/auth/google.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
+import { prevPathState } from '@src/atoms/login';
+import { requestLogin } from '@src/services';
+import { useMutation } from 'react-query';
+import { useEffect } from 'react';
+
+function Google() {
+  const router = useRouter();
+  const prevPath = useRecoilValue(prevPathState);
+  const url = router.asPath;
+  const code = url?.split('#access_token=')[1]?.split('&')[0];
+  const { mutate } = useMutation(requestLogin, {
+    onSuccess: () => {
+      if (prevPath === '/organizerOnboarding') {
+        router.push('/');
+      } else {
+        router.push(prevPath);
+      }
+    },
+    onError: () => {
+      console.error('로그인 요청이 실패했습니다.');
+      router.push(prevPath);
+    },
+  });
+  useEffect(() => {
+    mutate({ social: 'GOOGLE', token: code });
+  }, [code, mutate]);
+  return <></>;
+}
+
+export default Google;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import ImageDiv from '@src/components/common/ImageDiv';
 import { imgMainBackground, imgBackgroundItems, imgMainCharacters, imgMainLogo } from '@src/assets/images';
 import BottomButton from '@src/components/common/BottomButton';
 import useManageScroll from '@src/hooks/UseManageScroll';
+import GoogleLoginButton from '@src/components/common/GoogleLoginButton';
 
 function Home() {
   useManageScroll();
@@ -21,6 +22,7 @@ function Home() {
           <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'초대장 만들기'} />
         </Link>
       </StInviteButton>
+      <GoogleLoginButton />
     </StHome>
   );
 }

--- a/src/pages/invite/[teamId].tsx
+++ b/src/pages/invite/[teamId].tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import InviteModal from '@src/components/shareModule/InviteModal';
 import Link from 'next/link';
+import { DOMAIN } from '@src/constants/domain';
 
 interface ctxType {
   query: {
@@ -36,7 +37,7 @@ function ConfirmInvite({ teamId, teamName }: ConfirmInviteProps) {
         title="T.time | 팀과 내가 함께 성장하는 시간"
         ogTitle={teamName + '팀 초대장이 도착했어요!'}
         description="초대장을 열고, 티타임에 입장해보세요.☕️"
-        url={'https://t-time.vercel.app/join/' + teamId}
+        url={DOMAIN + '/join/' + teamId}
       />
       {modalState && teamName ? (
         <InviteModal teamName={teamName} setModalState={setModalState} teamId={String(router.query.teamId)} />

--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -18,6 +18,7 @@ import LoadingView from '@src/components/common/LoadingView';
 import MyResultModal from '@src/components/shareModule/MyResultModal';
 import { useRouter } from 'next/router';
 import { imgCenturyGothicLogo } from '@src/assets/images';
+import { DOMAIN } from '@src/constants/domain';
 interface ctxType {
   query: {
     userId: string;
@@ -64,7 +65,7 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
         ogTitle={myResultData.nickname + '님의 T.time 결과를 확인해보세요'}
         description="개인결과는 링크가 있는 사람만 볼 수 있어요.☕️"
         image="/img_personalShare.png"
-        url={'https://t-time.vercel.app/myResult/noTeam/' + userId}
+        url={DOMAIN + '/myResult/noTeam/' + userId}
       />
       <LogoTop />
       {resultData ? (

--- a/src/pages/teamResult/[teamId]/[userId].tsx
+++ b/src/pages/teamResult/[teamId]/[userId].tsx
@@ -12,6 +12,7 @@ import { getCompleted } from '../../../services/index';
 import LoadingView from '@src/components/common/LoadingView';
 import { getTeamData } from '@src/services/index';
 import { TeamInfoData } from '@src/services/types';
+import { DOMAIN } from '@src/constants/domain';
 
 interface ctxType {
   query: {
@@ -56,7 +57,7 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
         ogTitle={teamData?.teamName + '의 팀결과를 확인해보세요'}
         description="팀 결과를 팀원들과 공유해 깊은 이야기를 나눠보세요.☕️"
         image="/img_teamShare.png"
-        url={'https://t-time.vercel.app/myResult/' + teamId + '/noUser'}
+        url={DOMAIN + '/myResult/' + teamId + '/noUser'}
       />
       <LogoTop />
       {completeData ? (

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,5 @@
 import { api } from './base';
-import { TeamData } from './types';
+import { TeamData, RequestLoginBody } from './types';
 
 export const test = async (body: object) => {
   await api.post({ url: `/api/team/729262811`, data: body });
@@ -52,5 +52,10 @@ export const postAnswer = async (teamId: number, body: object) => {
 };
 export const patchComplete = async (userId: number) => {
   const { data } = await api.patch({ url: `/api/result/${userId}`, data: { isCompleted: true } });
+  return data;
+};
+
+export const requestLogin = async (body: RequestLoginBody) => {
+  const { data } = await api.post({ url: `/api/user/auth`, data: body });
   return data;
 };

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,9 +1,3 @@
-//example
-export type Favorite = {
-  id: string;
-  mint: string;
-  choco: string;
-};
 export type Invite = {
   status: number;
   success: boolean;
@@ -80,4 +74,8 @@ export type TeamDetailResult = {
   nickname: string;
   questionNumber: number;
   questionType: string;
+};
+export type RequestLoginBody = {
+  social: string;
+  token: string;
 };


### PR DESCRIPTION
## 🚩 관련 이슈
- close #123 

## 📋 구현 기능 명세
- [x] 리다이렉트 후 인가코드 받아오기
- [x] 로그인/회원가입 요청
- [x] 티타임 accessToken 저장
- [x] 팀 결과 페이지 닉네임 자릿수 조정

## 📌 PR Point
- 로그인 요청 서버를 추가했습니다.
- 하윤이가 맡은 카카오 로그인과 같은 듯 다른 듯.. 싶어서 PR 올라오면 확인하고 조금 더 통일감 있는 방향으로 수정할 예정입니다!
- google.tsx의 로그인 로직

> GoogleLoginButton 누른다 > google 소셜 로그인 페이지로 이동해서 구글 로그인 > /auth/google 로 이동 > url에 있는 인가 코드(#access_token=) 가지고 requestLogin 서버에 요청 > 로그인 성공 > 다음 페이지로 push

- 팀 결과 페이지 닉네임 4자리 이상이면 `ㅇㅇㅇ...` 형태로 바꿔주도록 하는 코드를 추가했습니다.
- 주석 제거