### PR TITLE
[participantOnboarding / Main]QA반영

### DIFF
--- a/src/pages/auth/google.tsx
+++ b/src/pages/auth/google.tsx
@@ -28,6 +28,7 @@ function Google() {
 
   useEffect(() => {
     localStorage.setItem('accessToken', data?.accessToken);
+    localStorage.setItem('nickName', data?.name);
   }, [data]);
 
   return <></>;

--- a/src/pages/auth/kakao.tsx
+++ b/src/pages/auth/kakao.tsx
@@ -29,6 +29,7 @@ function KakaoAuth() {
   useEffect(() => {
     if (userData.data != undefined) {
       localStorage.setItem('accessToken', userData.data.accessToken);
+      localStorage.setItem('nickNmae', userData.data.name);
       if (prevPath === '/organizerOnboarding') {
         router.push('/');
       } else {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,12 +7,15 @@ import { imgMainBackground, imgBackgroundItems, imgMainCharacters, imgMainLogo }
 import BottomButton from '@src/components/common/BottomButton';
 import useManageScroll from '@src/hooks/UseManageScroll';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 
 function Home() {
   const [isLogin, setIsLogIn] = useState(false);
+  const router = useRouter();
   useEffect(() => {
     const item = localStorage.getItem('accessToken');
-    if (item) setIsLogIn(true);
+    if (!item) router.push('/organizerOnboarding');
+    else setIsLogIn(true);
   }, []);
   useManageScroll();
   return (

--- a/src/pages/myPage/index.tsx
+++ b/src/pages/myPage/index.tsx
@@ -18,6 +18,7 @@ function MyPage() {
       <StLogoutBtn
         onClick={() => {
           localStorage.removeItem('accessToken');
+          localStorage.removeItem('nickName');
           router.push('/organizerOnboarding');
         }}>
         Logout

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -20,8 +20,8 @@ function ParticipantOnboarding() {
   const router = useRouter();
   const [nickName, setNickName] = useState('');
   useEffect(() => {
-    const nick = localStorage.getItem('nickName');
-    if (nick) setNickName(nick);
+    const localNickname = localStorage.getItem('nickName');
+    if (localNickname) setNickName(localNickname);
   }, []);
   return (
     <StParticipantOnboarding>

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import LogoTop from '@src/components/common/LogoTop';
 import BottomButton from '@src/components/common/BottomButton';
-
 import ImageDiv from '@src/components/common/ImageDiv';
 import {
   imgParticipantFirst,
@@ -19,6 +18,11 @@ import {
 
 function ParticipantOnboarding() {
   const router = useRouter();
+  const [nickName, setNickName] = useState('');
+  useEffect(() => {
+    const nick = localStorage.getItem('nickName');
+    if (nick) setNickName(nick);
+  }, []);
   return (
     <StParticipantOnboarding>
       <Link href={`/join/${router.query.teamId}`}>
@@ -76,7 +80,7 @@ function ParticipantOnboarding() {
       </StFifthPart>
       <StSixthPart>
         <StSixthText>
-          우리는 <StOrangeText>티타임짱..</StOrangeText>님이
+          우리는 <StOrangeText>{nickName}</StOrangeText>님이
           <br /> 티타임에 솔직하게 <br />
           참여해주실 것이라고 믿어요 :)
         </StSixthText>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #132 

## 📋 구현 기능 명세
- [x] 로그인 안 되어 있을 시 메인페이지에서 organizerOnboarding 으로 이동
- [x] participantOnboarding에서 참여자 이름 가져와서 표시

## 📌 PR Point
- index.tsx의 useEffect에서 accesstoken을 가져오는데, 값이 없으면 router.push()를 사용하여 페이지를 이동시켜주었습니다.
- participantOnboarding에서 이름을 사용해야했기에, 구글 / 카카오 로그인 과정에서 setItem을 통해 nickName을 키값으로 하는 이름을 넣어주고, 온보딩 페이지에서 가져와서 사용했습니다
- 로그아웃 시 닉네임도 없어지도록 removeItem('nickName') 코드를 추가했습니다.

## 📸 결과물 스크린샷
<img width="316" alt="image" src="https://user-images.githubusercontent.com/87795291/222872783-2f41667b-e62c-4dc2-8e0e-992ae1dd4083.png">

