### PR TITLE
[join] 로그인 여부에 따른 참가자 온보딩 페이지 로직 구현

### DIFF
--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -34,12 +34,13 @@ function Join() {
   const teamId = Number(router.asPath.split('/')[2]);
   const isLogin = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
   useEffect(() => {
-    localStorage.setItem('teamId', String(teamId));
-  }, []);
+    if (router.isReady) {
+      localStorage.setItem('teamId', String(teamId));
+    }
+  }, [router]);
   const { data } = useQuery('teamData', () => getTeamData(teamId), {
     enabled: !!teamId,
   });
-  console.log(isLogin);
   const getData = useMutation(
     () =>
       enterChat(
@@ -166,16 +167,16 @@ const StListContainer = styled.ol`
 `;
 
 const StLoginInfoText = styled.p`
-  color: ${COLOR.GRAY_7E};
-  ${FONT_STYLES.PRETENDARD_M_12};
   margin-top: 10.4rem;
   margin-bottom: 1rem;
-`;
-const StUnLoginInfoText = styled.p`
   color: ${COLOR.GRAY_7E};
   ${FONT_STYLES.PRETENDARD_M_12};
+`;
+const StUnLoginInfoText = styled.p`
   margin-top: 6rem;
   margin-bottom: 1rem;
+  color: ${COLOR.GRAY_7E};
+  ${FONT_STYLES.PRETENDARD_M_12};
 `;
 const StList = styled.li`
   &:not(:last-child) {

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -79,19 +79,21 @@ function Join() {
           <StList>예상 소요시간: 약 10분 이내</StList>
         </StListContainer>
       </StMainContainer>
+
       {isLogin ? (
         <>
-          <StInfoText>지금 바로 T.time 시작해보세요!</StInfoText>
+          <StLoginInfoText>지금 바로 T.time 시작해보세요!</StLoginInfoText>
           <StButtonContainer onClick={handleSubmit}>
             <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'다음'} />
           </StButtonContainer>
         </>
       ) : (
         <>
+          <StUnLoginInfoText>지금 바로 T.time 시작해보세요!</StUnLoginInfoText>
           <GoogleLoginButton />
-          <StKakaoButton>
+          <StKakaoButtonContainer>
             <KakaoLoginButton />
-          </StKakaoButton>
+          </StKakaoButtonContainer>
         </>
       )}
     </StJoin>
@@ -159,10 +161,16 @@ const StListContainer = styled.ol`
   list-style-type: disc;
 `;
 
-const StInfoText = styled.p`
+const StLoginInfoText = styled.p`
   color: ${COLOR.GRAY_7E};
   ${FONT_STYLES.PRETENDARD_M_12};
   margin-top: 10.4rem;
+  margin-bottom: 1rem;
+`;
+const StUnLoginInfoText = styled.p`
+  color: ${COLOR.GRAY_7E};
+  ${FONT_STYLES.PRETENDARD_M_12};
+  margin-top: 6rem;
   margin-bottom: 1rem;
 `;
 const StList = styled.li`
@@ -171,6 +179,10 @@ const StList = styled.li`
   }
   color: ${COLOR.BLACK};
   ${FONT_STYLES.NEXON_R_16};
+`;
+
+const StKakaoButtonContainer = styled.div`
+  margin-top: 1.6rem;
 `;
 
 const StButtonContainer = styled.button``;

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -6,7 +6,7 @@ import { FONT_STYLES } from '@src/styles/fontStyle';
 import { imgCenturyGothicLogo, imgJoin } from '@src/assets/images';
 import ImageDiv from '@src/components/common/ImageDiv';
 import BottomButton from '@src/components/common/BottomButton';
-import { ChangeEvent, useState } from 'react';
+
 import { useRouter } from 'next/router';
 import { enterChat } from '@src/services';
 import { useMutation } from 'react-query';
@@ -14,6 +14,8 @@ import { TeamData } from '@src/mocks/types';
 import useManageScroll from '@src/hooks/UseManageScroll';
 import { useQuery } from 'react-query';
 import { getTeamData } from '@src/services';
+import GoogleLoginButton from '@src/components/common/GoogleLoginButton';
+import KakaoLoginButton from '@src/components/common/KakaoLoginButton';
 
 interface IApiError {
   response: {
@@ -29,19 +31,16 @@ function Join() {
   useManageScroll();
   const router = useRouter();
   const teamId = Number(router.asPath.split('/')[2]);
-  const [nickname, setNickname] = useState<string>('');
-
+  const isLogin = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
   const { data } = useQuery('teamData', () => getTeamData(teamId), {
     enabled: !!teamId,
   });
-
+  console.log(isLogin);
   const getData = useMutation(
     () =>
       enterChat(
         teamId,
-        {
-          nickname: nickname,
-        },
+
         localStorage.getItem('accessToken'),
       ),
     {
@@ -60,24 +59,7 @@ function Join() {
   );
 
   const handleSubmit = () => {
-    if (nickname.length == 0) {
-      alert('닉네임을 입력해주세요.');
-    } else {
-      getData.mutate();
-    }
-  };
-
-  const handleNickChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const korean = /^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]+$/;
-    if (e.target.value.length < 5) {
-      if (korean.test(e.currentTarget.value) == false && e.target.value != '') {
-        alert('닉네임은 한글만 입력 가능해요.');
-      } else {
-        setNickname(e.target.value);
-      }
-    } else {
-      alert('닉네임은 최대 4자까지 입력 가능해요.');
-    }
+    getData.mutate();
   };
 
   return (
@@ -97,17 +79,21 @@ function Join() {
           <StList>예상 소요시간: 약 10분 이내</StList>
         </StListContainer>
       </StMainContainer>
-      <StInputContainer>
-        <StNickname>참여자 닉네임</StNickname>
-        <StInputBox
-          placeholder="닉네임을 입력해주세요"
-          onChange={(e) => handleNickChange(e)}
-          value={nickname || ''}></StInputBox>
-        <StNotice>4글자 이내 한글로 입력해주세요</StNotice>
-      </StInputContainer>
-      <StButtonContainer onClick={handleSubmit}>
-        <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'다음'} />
-      </StButtonContainer>
+      {isLogin ? (
+        <>
+          <StInfoText>지금 바로 T.time 시작해보세요!</StInfoText>
+          <StButtonContainer onClick={handleSubmit}>
+            <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'다음'} />
+          </StButtonContainer>
+        </>
+      ) : (
+        <>
+          <GoogleLoginButton />
+          <StKakaoButton>
+            <KakaoLoginButton />
+          </StKakaoButton>
+        </>
+      )}
     </StJoin>
   );
 }
@@ -173,48 +159,18 @@ const StListContainer = styled.ol`
   list-style-type: disc;
 `;
 
+const StInfoText = styled.p`
+  color: ${COLOR.GRAY_7E};
+  ${FONT_STYLES.PRETENDARD_M_12};
+  margin-top: 10.4rem;
+  margin-bottom: 1rem;
+`;
 const StList = styled.li`
   &:not(:last-child) {
     margin-bottom: 1.2rem;
   }
   color: ${COLOR.BLACK};
   ${FONT_STYLES.NEXON_R_16};
-`;
-
-const StInputContainer = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  flex-direction: column;
-  width: 29.4rem;
-  margin-bottom: 3rem;
-`;
-
-const StNickname = styled.p`
-  margin: 0 0 0.5rem 0.8rem;
-  color: ${COLOR.BLUE_TEXT};
-  ${FONT_STYLES.NEXON_B_16};
-`;
-
-const StInputBox = styled.input`
-  width: 121.428571%; // 17/14 * 100
-  padding: 1.45714285rem; // 기존값1.2rem * 121.428571%
-  margin-bottom: 0.971428568rem;
-  margin-right: -21.428571%; // bottom 기존값0.8rem * 121.428571%
-  border: none;
-  border-radius: 0;
-  border-bottom: 0.121428571rem solid ${COLOR.GRAY_7E};
-  outline: none !important;
-  background: none;
-  ${FONT_STYLES.NEXON_R_16};
-  font-size: 1.7rem; // 17px 기준 줌인이 안 되므로 17로 지정
-  line-height: 2.18571428rem; // 기존값1.8rem * 121.428571%
-  transform: scale(0.82352941); // 14/17 * 100
-  transform-origin: left top;
-`;
-
-const StNotice = styled.p`
-  color: ${COLOR.BLUE_TEXT};
-  ${FONT_STYLES.NEXON_R_12};
 `;
 
 const StButtonContainer = styled.button``;

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -16,7 +16,7 @@ import { useQuery } from 'react-query';
 import { getTeamData } from '@src/services';
 import GoogleLoginButton from '@src/components/common/GoogleLoginButton';
 import KakaoLoginButton from '@src/components/common/KakaoLoginButton';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface IApiError {
   response: {
@@ -32,7 +32,11 @@ function Join() {
   useManageScroll();
   const router = useRouter();
   const teamId = Number(router.asPath.split('/')[2]);
-  const isLogin = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+  const [isLogin, setIsLogin] = useState<string | null>('');
+  useEffect(() => {
+    setIsLogin(localStorage.getItem('accessToken'));
+  }, []);
+
   useEffect(() => {
     if (router.isReady) {
       localStorage.setItem('teamId', String(teamId));

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -16,6 +16,7 @@ import { useQuery } from 'react-query';
 import { getTeamData } from '@src/services';
 import GoogleLoginButton from '@src/components/common/GoogleLoginButton';
 import KakaoLoginButton from '@src/components/common/KakaoLoginButton';
+import { useEffect } from 'react';
 
 interface IApiError {
   response: {
@@ -32,6 +33,9 @@ function Join() {
   const router = useRouter();
   const teamId = Number(router.asPath.split('/')[2]);
   const isLogin = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+  useEffect(() => {
+    localStorage.setItem('teamId', String(teamId));
+  }, []);
   const { data } = useQuery('teamData', () => getTeamData(teamId), {
     enabled: !!teamId,
   });

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -8,6 +8,7 @@ import LogoTop from '@src/components/common/LogoTop';
 import BottomButton from '@src/components/common/BottomButton';
 
 import ImageDiv from '@src/components/common/ImageDiv';
+import { useState, useEffect } from 'react';
 import {
   imgParticipantFirst,
   imgParticipantSecond,
@@ -18,7 +19,10 @@ import {
 } from '@src/assets/images';
 
 function ParticipantOnboarding() {
-  const teamId = typeof window !== 'undefined' ? localStorage.getItem('teamId') : null;
+  const [teamId, setTeamId] = useState<string | null>('');
+  useEffect(() => {
+    setTeamId(localStorage.getItem('teamId'));
+  }, []);
   return (
     <StParticipantOnboarding>
       <Link href={`/join/${teamId}`}>

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -3,11 +3,9 @@ import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import Link from 'next/link';
-
 import LogoTop from '@src/components/common/LogoTop';
 import BottomButton from '@src/components/common/BottomButton';
 import ImageDiv from '@src/components/common/ImageDiv';
-import { useState, useEffect } from 'react';
 import {
   imgParticipantFirst,
   imgParticipantSecond,
@@ -22,7 +20,6 @@ function ParticipantOnboarding() {
   useEffect(() => {
     setTeamId(localStorage.getItem('teamId'));
   }, []);
-  const router = useRouter();
   const [nickName, setNickName] = useState('');
   useEffect(() => {
     const localNickname = localStorage.getItem('nickName');

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
+
 import LogoTop from '@src/components/common/LogoTop';
 import BottomButton from '@src/components/common/BottomButton';
 
@@ -18,10 +18,10 @@ import {
 } from '@src/assets/images';
 
 function ParticipantOnboarding() {
-  const router = useRouter();
+  const teamId = typeof window !== 'undefined' ? localStorage.getItem('teamId') : null;
   return (
     <StParticipantOnboarding>
-      <Link href={`/join/${router.query.teamId}`}>
+      <Link href={`/join/${teamId}`}>
         <StartButton>
           <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'시작하기'} />
         </StartButton>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -36,7 +36,7 @@ export const getTeamDetailResult = async (teamId: number, type: string) => {
   return { data };
 };
 
-export const enterChat = async (teamId: number, body: object, token: string | null): Promise<TeamData> => {
+export const enterChat = async (teamId: number, token: string | null): Promise<TeamData> => {
   const { data } = await api.post({
     url: `/api/team/${teamId}`,
     headers: { 'Content-Type': 'application/json', Authorization: token },


### PR DESCRIPTION
## 🚩 관련 이슈
- close #130 

## 📋 구현 기능 명세
- [x] 사용자 로그인 여부 판단 후 온보딩 페이지 연결
- [x] 로그인 연결
- [x] 참가자 온보딩 페이지에 teamId 전달 

## 📌 PR Point
- 현재 join 페이지에서, 사용자의 로그인 여부에 따라서 로그인을 하거나, 챗으로 넘어가거나 하는 뷰 및 기능을 구현했습니다!
- 추가로, join 페이지로 다시 돌아오기 위해서 참가자 온보딩 페이지에 teamId를 넘겨줘야해서, localStorage를 하나 더 사용했어요!
- 
## 📸 결과물 스크린샷