### PR TITLE
[Onboarding]QA반영 참여자, 주최자 온보딩 수정

### DIFF
--- a/src/pages/organizerOnboarding.tsx
+++ b/src/pages/organizerOnboarding.tsx
@@ -36,7 +36,7 @@ function OrganizerOnboarding() {
         {ORGANIZER_SLIDER_ITEMS.map((item, idx) => (
           <StOnboardingWrapper key={idx}>
             <StFlex>
-              <PageText>{ORGANIZER_SLIDER_ITEMS[item.id - 1].text}</PageText>
+              <StPageText>{ORGANIZER_SLIDER_ITEMS[item.id - 1].text}</StPageText>
               <ImageDiv
                 src={ORGANIZER_SLIDER_ITEMS[item.id - 1].image}
                 alt="주최자 온보딩 이모티콘"
@@ -166,7 +166,7 @@ const StSlider = styled(Slider)`
   }
 `;
 
-const PageText = styled.p`
+const StPageText = styled.p`
   position: relative;
   margin-top: 7.2rem;
   text-align: center;

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -97,77 +97,93 @@ const StartButton = styled.div`
   left: 50%;
   filter: drop-shadow(0 0.2rem 1rem rgba(255, 108, 61, 0.5));
   z-index: 2;
-  margin-left: -13.5rem;
-  margin-top: 30rem;
+  margin: 30rem 0 0 -13.5rem;
 `;
 
 const StSixthText = styled.p`
   text-align: center;
-  ${FONT_STYLES.NEXON_R_22};
+  ${FONT_STYLES.NEXON_B_22};
 `;
 
 const StSixthPart = styled.div`
   .imgParticipantTart {
     position: relative;
+    top: 50%;
+    left: 50%;
     width: 47.8rem;
     height: 37.5rem;
-    margin: 1.5rem 0 0 1.6rem;
+    margin-top: 3rem;
+    margin-left: -19.9rem;
   }
 `;
 
 const StFifthPart = styled.div`
+  position: relative;
+  top: 50%;
+  left: 50%;
+  margin-top: -0.5rem;
+  margin-left: -25.4rem;
   .imgParticipantCanele {
     position: relative;
     width: 42.7rem;
     height: 30.8rem;
-    margin: 0.637rem 0 0 -5.748rem;
   }
 `;
 
 const StFourthText = styled.p`
-  margin-top: -8.678rem;
+  margin-top: 8.678rem;
   text-align: center;
-  ${FONT_STYLES.NEXON_R_22};
+  ${FONT_STYLES.NEXON_B_22};
 `;
 
 const StFourthPart = styled.div`
   .imgParticipantFourth {
     position: relative;
+    top: 50%;
+    left: 50%;
     width: 32.9rem;
     height: 32.9rem;
-    margin-left: 2.7rem;
+    margin-left: -16.45rem;
   }
 `;
 
 const StThirdText = styled.p`
-  margin: 2.779rem 2.1rem 0rem 0rem;
+  position: relative;
   text-align: right;
-  ${FONT_STYLES.NEXON_R_22};
-  z-index: 1;
+  left: -50%;
+  margin-right: -8.25rem;
+  ${FONT_STYLES.NEXON_B_22};
 `;
 
 const StThirdPart = styled.div`
+  position: relative;
+  top: 50%;
+  left: 50%;
+  margin-left: -22rem;
   .imgParticipantThird {
     position: relative;
-    position: relative;
-    top: -15rem;
-    left: -2.5rem;
     width: 39.4rem;
     height: 36.022rem;
+    margin-top: -14.011rem;
   }
 `;
 
 const StSecondText = styled.p`
   margin: 4.036rem 0 0 2.5rem;
-  ${FONT_STYLES.NEXON_R_22};
+  ${FONT_STYLES.NEXON_B_22};
 `;
 
 const StSecondPart = styled.div`
+  position: relative;
+  top: 50%;
+  left: 50%;
+  margin-left: -18.25rem;
+  margin-top: -1rem;
   .imgParticipantSecond {
     position: relative;
     width: 39.6rem;
     height: 37.1rem;
-    margin-left: 5.5rem;
+    margin-left: 4.4rem;
   }
 `;
 
@@ -182,7 +198,7 @@ const StBlueText = styled.span`
 const StFirstText = styled.p`
   text-align: center;
   margin-top: 3rem;
-  ${FONT_STYLES.NEXON_R_22};
+  ${FONT_STYLES.NEXON_B_22};
 `;
 
 const StFirstPart = styled.div`
@@ -190,6 +206,7 @@ const StFirstPart = styled.div`
   justify-content: center;
   flex-direction: column;
   align-items: center;
+  margin-top: 3rem;
   .imgParticipantFirst {
     position: relative;
     width: 30.1rem;

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -119,7 +119,7 @@ const StartButton = styled.div`
 
 const StSixthText = styled.p`
   text-align: center;
-  ${FONT_STYLES.NEXON_B_22};
+  ${FONT_STYLES.NEXON_OB_22};
 `;
 
 const StSixthPart = styled.div`
@@ -150,7 +150,7 @@ const StFifthPart = styled.div`
 const StFourthText = styled.p`
   margin-top: 8.678rem;
   text-align: center;
-  ${FONT_STYLES.NEXON_B_22};
+  ${FONT_STYLES.NEXON_OB_22};
 `;
 
 const StFourthPart = styled.div`
@@ -169,7 +169,7 @@ const StThirdText = styled.p`
   text-align: right;
   left: -50%;
   margin-right: -8.25rem;
-  ${FONT_STYLES.NEXON_B_22};
+  ${FONT_STYLES.NEXON_OB_22};
 `;
 
 const StThirdPart = styled.div`
@@ -187,7 +187,7 @@ const StThirdPart = styled.div`
 
 const StSecondText = styled.p`
   margin: 4.036rem 0 0 2.5rem;
-  ${FONT_STYLES.NEXON_B_22};
+  ${FONT_STYLES.NEXON_OB_22};
 `;
 
 const StSecondPart = styled.div`
@@ -215,7 +215,7 @@ const StBlueText = styled.span`
 const StFirstText = styled.p`
   text-align: center;
   margin-top: 3rem;
-  ${FONT_STYLES.NEXON_B_22};
+  ${FONT_STYLES.NEXON_OB_22};
 `;
 
 const StFirstPart = styled.div`

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -214,7 +214,7 @@ const StBlueText = styled.span`
 
 const StFirstText = styled.p`
   text-align: center;
-  margin-top: 3rem;
+  margin-top: 6rem;
   ${FONT_STYLES.NEXON_OB_22};
 `;
 

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -40,7 +40,7 @@ function ParticipantOnboarding() {
       <StSecondPart>
         <StSecondText>
           티타미의 질문에
-          <br /> <StOrangeText>솔직하게</StOrangeText>대답해주세요.
+          <br /> <StOrangeText>솔직하게 </StOrangeText>대답해주세요.
         </StSecondText>
         <ImageDiv
           src={imgParticipantSecond.src}

--- a/src/pages/participantOnboarding.tsx
+++ b/src/pages/participantOnboarding.tsx
@@ -26,7 +26,10 @@ function ParticipantOnboarding() {
           <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'시작하기'} />
         </StartButton>
       </Link>
-      <LogoTop />
+      <StLogo>
+        <LogoTop />
+      </StLogo>
+
       <StFirstPart>
         <StFirstText>
           티타임은 나와 팀이 <StBlueText>함께</StBlueText>
@@ -47,11 +50,13 @@ function ParticipantOnboarding() {
         />
       </StSecondPart>
       <StThirdPart>
-        <StThirdText>
-          점수는 <br />
-          <StOrangeText>1점 ~ 5점</StOrangeText>으로 <br />
-          구성되어 있어요.
-        </StThirdText>
+        <StWrapper>
+          <StThirdText>
+            점수는 <br />
+            <StOrangeText>1점 ~ 5점</StOrangeText>으로 <br />
+            구성되어 있어요.
+          </StThirdText>
+        </StWrapper>
         <ImageDiv src={imgParticipantThird.src} alt="imgParticipantThird" className="imgParticipantThird" fill={true} />
       </StThirdPart>
       <StFourthPart>
@@ -87,6 +92,18 @@ function ParticipantOnboarding() {
 }
 
 export default ParticipantOnboarding;
+
+const StWrapper = styled.div`
+  max-width: 39rem;
+  margin-left: 11rem;
+`;
+
+const StLogo = styled.div`
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 1;
+`;
 
 const StartButton = styled.div`
   display: flex;
@@ -216,5 +233,6 @@ const StFirstPart = styled.div`
 `;
 
 const StParticipantOnboarding = styled.div`
+  width: 100vw;
   overflow: hidden;
 `;

--- a/src/styles/fontStyle.ts
+++ b/src/styles/fontStyle.ts
@@ -111,6 +111,7 @@ export const FONT_STYLES = {
   NEXON_R_14: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 14, weight: 'R', height: 16 }),
   NEXON_R_16: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 16, weight: 'R', height: 18 }),
   NEXON_R_22: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 22, weight: 'R', height: 30.8 }),
+  NEXON_OB_22: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 22, weight: 'B', height: 30.8 }),
   NEXON_B_12: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 12, weight: 'B', height: 14 }),
   NEXON_B_14: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 14, weight: 'B', height: 16 }),
   NEXON_B_16: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 16, weight: 'B', height: 14 }),


### PR DESCRIPTION
## 🚩 관련 이슈
- close #137 

## 📋 구현 기능 명세
- [x] 참여자 온보딩 위치 전체적으로 센터 고정
- [x] 참여자 온보딩 Bold체로 변경
- [x] 주최자, 참여자 온보딩 스타일 컨벤션  

## 📌 PR Point
🔓 참여자 온보딩 위치 설정 중  `점수는 1~5점으로 구성되어 있어요.`부분은 `text-align: right;`으로 해야 오른쪽으로 텍스트 정렬이 되는데 이렇게 되면 `position:relative;`, `top:50;`, `left:50%`를 해도 화면 정가운데로 오지 않고 화면 오른쪽 끝에 계속 붙어 있더라구요...!! 이 점 참고 해주세욥~

## 📸 결과물 스크린샷
![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/108226647/222905955-c5e0f368-61ee-40c0-81b8-ac0936475b8c.gif)
