### PR TITLE
[common] 카카오 인앱 브라우저 감지 후 조치

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,7 +25,7 @@ function Home() {
       <ImageDiv src={imgBackgroundItems} alt="배경 아이템" className="backgroundItems" />
       <ImageDiv src={imgMainLogo} alt="티타임 로고" className="logoIcon" fill={true} />
       <ImageDiv src={imgMainBackground} alt="배경" className="mainBackground" fill={true} />
-      <StInviteButton>
+      <StButtonContainer>
         <Link href="/invite">
           <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'초대장 만들기'} />
         </Link>
@@ -34,7 +34,7 @@ function Home() {
             <BottomButton width={28.2} color={COLOR.BLUE_1} text={'지난 T.time 확인하기'} />
           </Link>
         )}
-      </StInviteButton>
+      </StButtonContainer>
     </StHome>
   );
 }
@@ -57,7 +57,7 @@ const StHome = styled.div`
   .mainCharacters {
     z-index: 2;
     position: relative;
-    top: 13.1rem;
+    top: 8.1rem;
     width: 34.4rem;
     height: 39.3rem;
     animation: ${characterAnimation} 3s infinite linear alternate;
@@ -66,13 +66,13 @@ const StHome = styled.div`
   .backgroundItems {
     z-index: 2;
     position: absolute;
-    top: 8.6rem;
+    top: 3.6rem;
   }
 
   .logoIcon {
     z-index: 2;
     position: absolute;
-    top: 25.3rem;
+    top: 20.3rem;
     width: 11.8rem;
     height: 6.1rem;
   }
@@ -86,13 +86,13 @@ const StHome = styled.div`
   }
 `;
 
-const StInviteButton = styled.div`
+const StButtonContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   gap: 1.6rem;
-  position: fixed;
-  top: 57.1rem;
+  position: absolute;
+  top: 50.7rem;
   z-index: 2;
 `;

--- a/src/pages/invite/[teamId].tsx
+++ b/src/pages/invite/[teamId].tsx
@@ -160,6 +160,6 @@ const StBtnWrapper = styled.div`
 `;
 
 const StConfirmBtn = styled.div`
-  margin-top: 1.6rem;
+  margin-top: 1.8rem;
   cursor: pointer;
 `;

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -104,5 +104,5 @@ const StForm = styled.form`
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
-  margin-bottom: 8.4rem;
+  margin-bottom: 8.6rem;
 `;

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -200,18 +200,18 @@ const StList = styled.li`
 `;
 
 const StInfoText = styled.p<{ isLogin: string | null }>`
-  text-align: center;
-  color: ${COLOR.GRAY_7E};
-  ${FONT_STYLES.PRETENDARD_M_12};
   margin-bottom: 0.8rem;
   margin-top: ${(props) => props.isLogin && '4.4rem'};
+  color: ${COLOR.GRAY_7E};
+  ${FONT_STYLES.PRETENDARD_M_12};
+  text-align: center;
 `;
 
 const StLoginButtonContainer = styled.div<{ isKakaoBrowser: boolean }>`
-  position: relative;
-  bottom: 1rem;
   display: flex;
   flex-direction: column;
+  position: relative;
+  bottom: 1rem;
   margin-top: ${(props) => (props.isKakaoBrowser ? '7.6rem' : '1rem')};
 
   button:first-child {

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -46,6 +46,7 @@ function Join({ teamId, teamData }: JoinProps) {
   useManageScroll();
   const router = useRouter();
   const [isLogin, setIsLogin] = useState<string | null>('');
+  const [isKakaoBrowser, setIsKakaoBrowser] = useState(false);
   useEffect(() => {
     setIsLogin(localStorage.getItem('accessToken'));
   }, []);
@@ -76,11 +77,16 @@ function Join({ teamId, teamData }: JoinProps) {
     getData.mutate();
   };
 
+  useEffect(() => {
+    const isKakao = navigator.userAgent.match('KAKAOTALK');
+    setIsKakaoBrowser(Boolean(isKakao));
+  }, []);
+
   return (
     <StJoin>
       <SEO
         title="T.time | 팀과 내가 함께 성장하는 시간"
-        ogTitle={teamData.teamName + '팀 초대장이 도착했어요!'}
+        ogTitle={teamData?.teamName + '팀 초대장이 도착했어요!'}
         description="초대장을 열고, 티타임에 입장해보세요.☕️"
         url={DOMAIN + '/join/' + teamId}
       />
@@ -98,21 +104,20 @@ function Join({ teamId, teamData }: JoinProps) {
           <StList>예상 소요시간: 약 10분 이내</StList>
         </StListContainer>
       </StMainContainer>
-
       {isLogin ? (
         <>
-          <StLoginInfoText>지금 바로 T.time 시작해보세요!</StLoginInfoText>
-          <StButtonContainer onClick={handleSubmit}>
+          <StLoginButtonContainer onClick={handleSubmit} isKakaoBrowser={isKakaoBrowser}>
+            <StInfoText isLogin={isLogin}>지금 바로 T.time 시작해보세요!</StInfoText>
             <BottomButton width={28.2} color={COLOR.ORANGE_1} text={'다음'} />
-          </StButtonContainer>
+          </StLoginButtonContainer>
         </>
       ) : (
         <>
-          <StUnLoginInfoText>지금 바로 T.time 시작해보세요!</StUnLoginInfoText>
-          <GoogleLoginButton />
-          <StKakaoButtonContainer>
+          <StLoginButtonContainer isKakaoBrowser={isKakaoBrowser}>
+            <StInfoText isLogin={isLogin}>T.time 참여를 위해 로그인이 필요해요!</StInfoText>
+            {!isKakaoBrowser && <GoogleLoginButton />}
             <KakaoLoginButton />
-          </StKakaoButtonContainer>
+          </StLoginButtonContainer>
         </>
       )}
     </StJoin>
@@ -186,18 +191,6 @@ const StListContainer = styled.ol`
   list-style-type: disc;
 `;
 
-const StLoginInfoText = styled.p`
-  margin-top: 10.4rem;
-  margin-bottom: 1rem;
-  color: ${COLOR.GRAY_7E};
-  ${FONT_STYLES.PRETENDARD_M_12};
-`;
-const StUnLoginInfoText = styled.p`
-  margin-top: 6rem;
-  margin-bottom: 1rem;
-  color: ${COLOR.GRAY_7E};
-  ${FONT_STYLES.PRETENDARD_M_12};
-`;
 const StList = styled.li`
   &:not(:last-child) {
     margin-bottom: 1.2rem;
@@ -206,8 +199,22 @@ const StList = styled.li`
   ${FONT_STYLES.NEXON_R_16};
 `;
 
-const StKakaoButtonContainer = styled.div`
-  margin-top: 1.6rem;
+const StInfoText = styled.p<{ isLogin: string | null }>`
+  text-align: center;
+  color: ${COLOR.GRAY_7E};
+  ${FONT_STYLES.PRETENDARD_M_12};
+  margin-bottom: 0.8rem;
+  margin-top: ${(props) => props.isLogin && '4.4rem'};
 `;
 
-const StButtonContainer = styled.button``;
+const StLoginButtonContainer = styled.div<{ isKakaoBrowser: boolean }>`
+  position: relative;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  margin-top: ${(props) => (props.isKakaoBrowser ? '7.6rem' : '1rem')};
+
+  button:first-child {
+    margin-bottom: 1.6rem;
+  }
+`;

--- a/src/pages/organizerOnboarding.tsx
+++ b/src/pages/organizerOnboarding.tsx
@@ -1,7 +1,7 @@
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import Slider from 'react-slick';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
 import BottomButton from '@src/components/common/BottomButton';
@@ -14,6 +14,7 @@ import KakaoLoginButton from '@src/components/common/KakaoLoginButton';
 function OrganizerOnboarding() {
   const sliderRef = useRef<Slider>(null);
   const [currentSlide, setCurrentSlide] = useState(0);
+  const [isKakaoBrowser, setIsKakaoBrowser] = useState(false);
   const settings = {
     dots: true,
     dotsClass: 'customDots',
@@ -25,6 +26,12 @@ function OrganizerOnboarding() {
   const goToLastSlide = () => {
     sliderRef.current?.slickGoTo(4);
   };
+
+  useEffect(() => {
+    const isKakao = navigator.userAgent.match('KAKAOTALK');
+    setIsKakaoBrowser(Boolean(isKakao));
+  }, []);
+
   return (
     <>
       <StSlider
@@ -53,9 +60,9 @@ function OrganizerOnboarding() {
         </StSkipButton>
       ) : (
         <StSocialLoginButton>
-          <StInfor>SNS 계정으로 티타임을 편리하게 이용해 보세요.</StInfor>
-          <StLoginButtonContainer>
-            <GoogleLoginButton />
+          <StLoginButtonContainer isKakaoBrowser={isKakaoBrowser}>
+            <StInfor>SNS 계정으로 티타임을 편리하게 이용해 보세요.</StInfor>
+            {!isKakaoBrowser && <GoogleLoginButton />}
             <KakaoLoginButton />
           </StLoginButtonContainer>
         </StSocialLoginButton>
@@ -195,13 +202,19 @@ const StOnboardingWrapper = styled.div`
 `;
 
 const StInfor = styled.p`
+  margin-bottom: 0.8rem;
   color: ${COLOR.GRAY_7E};
   ${FONT_STYLES.PRETENDARD_M_12};
 `;
 
-const StLoginButtonContainer = styled.div`
+const StLoginButtonContainer = styled.div<{ isKakaoBrowser: boolean }>`
+  position: relative;
+  bottom: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 1.6rem;
-  margin-top: 1rem;
+  margin-top: ${(props) => (props.isKakaoBrowser ? '7.6rem' : '1rem')};
+
+  button:first-child {
+    margin-bottom: 1.6rem;
+  }
 `;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #143 

## 📋 구현 기능 명세
- [x] 카카오 브라우저 감지
- [x] useEffect로 구현

## 📌 PR Point
- 피그마에 디자인 선생님들이 남겨주신 대로 메인 페이지 배경 50px씩 상향 조정하였습니다!
- 통일감 있게 버튼 디자인 코드를 수정했습니다. 스타일 코드를 재사용하려고 노력해 봤는데요... 오히려 더 복잡해진 것 같기도 하고 차라리 props state별 컴포넌트를 만드는 게 나을지 고민이네요
- location의 user agent값에 KAKAO가 있는지 파악하는 코드를 작성했습니다. 로컬에서 작동 잘 되는 것 확인했습니다 :D
<img width="150" src="https://user-images.githubusercontent.com/99077953/223146003-e8ceef21-6a7e-457e-b25b-763d1583df11.PNG">

- 최대한 바텀 버튼의 위치가 동일한 곳에 있도록 신경 썼습니다!
- join버튼 텍스트가 로그인 유무에 따라 다른데 동일하게 들어가 있길래 수정했습니다

## 📸 결과물 스크린샷
<img width="300" alt="스크린샷 2023-03-06 오후 11 47 50" src="https://user-images.githubusercontent.com/99077953/223144055-b056ce95-38e7-40c4-a071-430481316eaf.png">
<img width="300" alt="스크린샷 2023-03-06 오후 11 48 01" src="https://user-images.githubusercontent.com/99077953/223144110-957893d3-2a5d-4d13-b48d-1db505fc02a8.png">
<img width="300" alt="스크린샷 2023-03-06 오후 11 48 20" src="https://user-images.githubusercontent.com/99077953/223144195-7feb2dfb-7c7c-4f9e-89ed-ccaa6f196d06.png">
<img width="300" alt="스크린샷 2023-03-06 오후 11 48 30" src="https://user-images.githubusercontent.com/99077953/223144244-f31e3d12-1c95-4626-a6af-9f848c3aff47.png">
<img width="300" alt="스크린샷 2023-03-06 오후 11 48 42" src="https://user-images.githubusercontent.com/99077953/223144297-a2b9e4c1-f8cd-4594-ad8c-3543618afd04.png">
