### PR TITLE
[common] useQuery 관련 리팩토링

### DIFF
--- a/src/components/teamResult/DetailResult.tsx
+++ b/src/components/teamResult/DetailResult.tsx
@@ -20,10 +20,11 @@ function DetailResult({ teamId }: TeamResultProps) {
   const [questionTwoList, setQuestionTwoList] = useState<TeamDetailResult[]>([]);
   const [currentTab, setCurrentTab] = useState<CategoryType>('협업');
   const { data } = useQuery(
-    ['teamDetailResult', currentTab],
+    ['teamDetailResult', teamId, currentTab],
     () => getTeamDetailResult(teamId, filterQuestionCategory(currentTab)),
     {
       enabled: !!teamId,
+      staleTime: 300000,
       keepPreviousData: true,
     },
   );

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -49,13 +49,11 @@ function Join({ teamId, teamData }: JoinProps) {
   const [isKakaoBrowser, setIsKakaoBrowser] = useState(false);
   useEffect(() => {
     setIsLogin(localStorage.getItem('accessToken'));
+    const isKakao = navigator.userAgent.match('KAKAOTALK');
+    setIsKakaoBrowser(Boolean(isKakao));
+    localStorage.setItem('teamId', String(teamId));
   }, []);
 
-  useEffect(() => {
-    if (router.isReady) {
-      localStorage.setItem('teamId', String(teamId));
-    }
-  }, [router]);
   const getData = useMutation(() => enterChat(teamId, localStorage.getItem('accessToken')), {
     onSuccess: (response: TeamData) => {
       router.push({
@@ -74,11 +72,6 @@ function Join({ teamId, teamData }: JoinProps) {
   const handleSubmit = () => {
     getData.mutate();
   };
-
-  useEffect(() => {
-    const isKakao = navigator.userAgent.match('KAKAOTALK');
-    setIsKakaoBrowser(Boolean(isKakao));
-  }, []);
 
   return (
     <StJoin>

--- a/src/pages/join/[teamId].tsx
+++ b/src/pages/join/[teamId].tsx
@@ -12,7 +12,6 @@ import { enterChat, getTeamData } from '@src/services';
 import { useMutation } from 'react-query';
 import { TeamData } from '@src/mocks/types';
 import useManageScroll from '@src/hooks/UseManageScroll';
-import { useQuery } from 'react-query';
 import GoogleLoginButton from '@common/GoogleLoginButton';
 import KakaoLoginButton from '@common/KakaoLoginButton';
 import { useEffect, useState } from 'react';
@@ -57,9 +56,6 @@ function Join({ teamId, teamData }: JoinProps) {
       localStorage.setItem('teamId', String(teamId));
     }
   }, [router]);
-  const { data } = useQuery('teamData', () => getTeamData(teamId), {
-    enabled: !!teamId,
-  });
   const getData = useMutation(() => enterChat(teamId, localStorage.getItem('accessToken')), {
     onSuccess: (response: TeamData) => {
       router.push({
@@ -96,13 +92,13 @@ function Join({ teamId, teamData }: JoinProps) {
       <ImageDiv src={imgJoin} alt="T.time_logo" className="imgJoin" fill></ImageDiv>
       <StMainContainer>
         <ToolTipIcon top={5.8} />
-        <StTeamName>&apos;{data?.teamName}&apos;</StTeamName>
+        <StTeamName>&apos;{teamData?.teamName}&apos;</StTeamName>
         <StRowContainer>
           <ImageDiv src={imgJoinLogo} alt="T.time_logo" className="imgCenturyGothicLogo" fill></ImageDiv>
           <StInviteComment>에 초대합니다</StInviteComment>
         </StRowContainer>
         <StListContainer>
-          <StList>총 {data?.teamMember}명</StList>
+          <StList>총 {teamData?.teamMember}명</StList>
           <StList>질문 개수: 10개</StList>
           <StList>예상 소요시간: 약 10분 이내</StList>
         </StListContainer>

--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -71,9 +71,7 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
       />
       <LogoTop />
       <ToolTip top={5.8} />
-      <Link href="/myPage">
-        <StMypageLink>지난 T.time 확인하기</StMypageLink>
-      </Link>
+
       {resultData ? (
         <StMyResult>
           {modalState && (
@@ -84,6 +82,9 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
               setModalState={setModalState}
             />
           )}
+          <Link href="/myPage">
+            <StMypageLink>지난 T.time 확인하기</StMypageLink>
+          </Link>
           <StResultCard>
             <StInfoContainer>
               <p className="date">{handleDate(resultData.date)}</p>

--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -1,7 +1,6 @@
 import SEO from '@common/SEO';
 import LogoTop from 'src/components/common/LogoTop';
 import styled from 'styled-components';
-import { useQuery } from 'react-query';
 import { useEffect, useState } from 'react';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
@@ -40,19 +39,14 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
   const [isVisitor, setIsVisitor] = useState(false);
   const { isReady, push } = useRouter();
 
-  const { data } = useQuery('userData', () => getMyResult(userId, teamId), {
-    initialData: myResultData,
-    enabled: !!userId,
-    onSuccess: (data) => {
-      if (data.result.length < 5) push('/unfinished');
-    },
-  });
   const [modalState, setModalState] = useState(false);
   useEffect(() => {
-    setResultData(data);
-    const inputData = setConstantIndex(data?.result[4]?.questionType);
+    if (myResultData.result.length < 5) push('/unfinished');
+    setResultData(myResultData);
+    const inputData = setConstantIndex(myResultData?.result[4]?.questionType);
     setResultCharacter(inputData);
-  }, [data]);
+  }, []);
+
   useEffect(() => {
     if (!isReady) return;
     if (localStorage.getItem('accessToken')) {

--- a/src/pages/teamResult/[teamId]/[userId].tsx
+++ b/src/pages/teamResult/[teamId]/[userId].tsx
@@ -66,13 +66,14 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
       />
       <LogoTop />
       <ToolTip top={5.8} />
-      <Link href="/myPage">
-        <StMypageLink>지난 T.time 확인하기</StMypageLink>
-      </Link>
+
       {completeData ? (
         completeData.completed && !isLoading ? (
           <>
-            {modalState ? <TeamModal teamName={teamData?.teamName} setModalState={setModalState} /> : <></>}
+            {modalState && <TeamModal teamName={teamData?.teamName} setModalState={setModalState} />}
+            <Link href="/myPage">
+              <StMypageLink>지난 T.time 확인하기</StMypageLink>
+            </Link>
             <ResultFrame teamId={teamId} />
             <BottomButtonContainer teamId={teamId} userId={userId} isUser={isUser} setModalState={setModalState} />
             <StBackground />

--- a/src/pages/teamResult/[teamId]/[userId].tsx
+++ b/src/pages/teamResult/[teamId]/[userId].tsx
@@ -45,12 +45,7 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
       }
     }
   }, [userId]);
-  const { data: completeData, isLoading } = useQuery('completeData', () => getCompleted(teamId), {
-    enabled: router.isReady,
-  });
-  const { data } = useQuery('getTeamData', () => getTeamData(teamId), {
-    initialData: teamData,
-  });
+  const { data: completeData, isLoading } = useQuery('completeData', () => getCompleted(teamId), {});
 
   return (
     <StTeamResult>
@@ -69,7 +64,7 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
       {completeData ? (
         completeData.completed && !isLoading ? (
           <>
-            {modalState ? <TeamModal teamName={data?.teamName} setModalState={setModalState} /> : <></>}
+            {modalState ? <TeamModal teamName={teamData?.teamName} setModalState={setModalState} /> : <></>}
             <ResultFrame teamId={teamId} />
             <BottomButtonContainer teamId={teamId} userId={userId} isUser={isUser} setModalState={setModalState} />
             <StBackground />

--- a/src/pages/teamResult/[teamId]/[userId].tsx
+++ b/src/pages/teamResult/[teamId]/[userId].tsx
@@ -30,6 +30,7 @@ interface TeamResultProps {
 
 function TeamResult({ teamId, teamData }: TeamResultProps) {
   const [modalState, setModalState] = useState(false);
+  const [completeState, setCompleteState] = useState(true);
   const [isUser, setIsUser] = useState(false);
   const router = useRouter();
   const [userId, setUserId] = useState('');
@@ -45,7 +46,14 @@ function TeamResult({ teamId, teamData }: TeamResultProps) {
       }
     }
   }, [userId]);
-  const { data: completeData, isLoading } = useQuery('completeData', () => getCompleted(teamId), {});
+  const { data: completeData, isLoading } = useQuery('completeData', () => getCompleted(teamId), {
+    enabled: completeState,
+    onSuccess: (completeData) => {
+      if (completeData.completed) {
+        setCompleteState(false);
+      }
+    },
+  });
 
   return (
     <StTeamResult>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #167 

## 📋 구현 기능 명세
- [x] 불필요한 쿼리문을 삭제합니다 
- [x] 리액트 쿼리의 캐싱 기능을 활용..!!해봅니다
- [x] 쿼리 외에도 중간중간 보이던 useEffect 함수들 중 조금 정리를 한 부분이 있어요..!

## 📌 PR Point
- 리팩토링이라고 하니 뭔가 좀 거창한데, 사실 별거 없습니닷 .... 수정된 코드들만 봐도 별거 없다는걸 알 수 있을거예요ㅎ ㅠ
- useEffect를 정리한 부분은, 저희가 ssr을 적용하기 이전에 라우터에서 유저아이디를 받아오거나 할때의 기준으로 작성된 코드들이 있길래 필요없는 부분들을 수정해줬습니다
- useQuery관련해서는 서버에서 더 이상 데이터를 받아오지 않아도 되는 부분/굳이 받아오지 않아도 되는 데이터를 받아오는 부분들을 수정했습니다. 
1. enabled옵션을 넣는다거나,
2. 쿼리문을 아예 삭제한다거나, 
3. staleTime을 지정한다거나.. 하는 방식으로요!

- 구글 로그인이나 카카오 로그인에서 사용하는 api문 같은 경우도 꼭 useQuery를 사용해서 써야하나...궁금해졌어요. 캐싱 기능을 사용하는것도, 서버상태와 클라 상태의 데이터 무결성을 위해 지속적으로 호출해야하는 api인 것도 아닌 단순히 한 번 날리는 api인데 useQuery로 감쌀 이유가 있을까..? !라는 의문이..!! 물론 onSuccess나 onError같은 옵션으로 결과 처리가 쉬워지긴 하는것 같은 느낌인데 @.@ .. 이럼 굳이 useQuery를 안 쓸 이유도 없는걸까요..?! 그냥..코드를 보다보니.. 궁금해졌습니다....


### 🐥코드 수정 부분(여기선 일부분만 적었습니다 ,,,전체 내용은 [여기에 있습니당...](https://www.notion.so/rimlog/T-time-react-query-useQuery-9ab754ab25eb4b77b48e1e3baff6d9d7#065c079f691b44a69b4fda504691fa2d))
src/pages/teamResult/teamId/userId 부분에서, 팀의 해피니스체크가 다 완료되었는지 계속 체크해야하는건 맞지만, 한 번 성공적인 데이터를 불러오고 나서는 서버에 계속 컴플리트 여부를 요청할 필요가 없습니다. 한 번 완료된 해피니스 체크는 미완료 상태로 변경될 가능성이 없기 때문입니다.

![image](https://user-images.githubusercontent.com/87795291/231451547-90e269f4-3766-490d-b452-449c23e4970a.png)
⇒ 문제 상황. 컴플리트가 true인 것을 확인한 후에도 포커스되거나, 마운트 될 때 계속해서 쿼리문이 실행되어 서버에 요청을 보내고 있다.

```javascript
const [completeState, setCompleteState] = useState(true);
const { data: completeData, isLoading } = useQuery('completeData', () => getCompleted(teamId), {
    enabled: completeState,
    onSuccess: (completeData) => {
      if (completeData.completed) {
        setCompleteState(false);
      }
    },
    onSettled: () => {
      console.log('useQuery 실행');
    },
  });
```

그래서 이렇게 코드를 변경해봤습니다. (onSettled 함수는 useQuery가 성공이든 에러든 실행되는 함수) enabled에 completeState를 넣어줬습니다. 해당 값은 초기에 true값이기 때문에 쿼리문이 정상적으로 실행되고, 팀의 해피니스체크가 완료되었는지 지속적으로 체크할 수 있습니다. 하지만 중간에 가져온 컴플리트 데이터가 트루(팀의 해피니스 체크 완료)면 더 이상 이 api를 호출하지 않아도 되기 때문에 completeState를 false로 바꿔주어 더 이상 불필요한 서버 요청을 하지 않도록 해줬습니다.

![image](https://user-images.githubusercontent.com/87795291/231452150-cf0078f4-d793-41ab-af5d-ae34e5303934.png)

![image](https://user-images.githubusercontent.com/87795291/231451723-850b189b-c24c-4ccd-b717-0d2d67e94ba2.png)

코드 변경 후에는 이렇게 해피니스체크가 완료되지 않았을 땐 지속적으로 쿼리문을 실행하여 팀의 체크가 완료되었는지 확인하고, 모두가 참여한게 확인 된 이후로는 더 이상 쿼리문이 실행이 안 되는걸 확인할 수 있었습니다


src/components/teamResult/DetailResult

```javascript
const { data } = useQuery(
    ['teamDetailResult', teamId, currentTab],
    () => getTeamDetailResult(teamId, filterQuestionCategory(currentTab)),
    {
      enabled: !!teamId,
      keepPreviousData: true,
      onSettled: () => {
        console.log(`${currentTab} 결과 확인`);
      },
    },
  );
```

기존 코드를 실행해보면

![image](https://user-images.githubusercontent.com/87795291/231452217-06d95b3e-1d5d-4b22-9888-6b8d136ff9cc.png)

이런식으로 탭을 누를때마다 새로 쿼리문을 또 실행합니다.

수정 코드를 실행하면

![캐싱데이터](https://user-images.githubusercontent.com/87795291/231451841-21c36892-cf71-426a-a37c-5f7b5ae2a0c8.gif)

staleTime을 300000 (5분)으로 지정해서 처음 호출 이후 5분동안은 캐싱 처리해주고, 같은 호출이 들어오면 캐싱된 데이터가 불러오게끔 해줬습니다. 움짤에서 보다시피 지금은 처음 호출시에만 api를 호출하고, 그 이후엔 캐싱된 데이터가 불러와지는걸 확인할 수 있습니다.

사실 팀 결과 또한 바뀔 가능성이 전혀 없는 데이터라서 5분 뒤에도 굳이 다시 불러올 필요가 없긴하지만, cacheTime(메모리에 저장된 캐싱 데이터가 유효한 시간)의 디폴트값 5분이라 cacheTime도 따로 지정해주지 않는 이상 staleTime을 아무리 늘려놔도 소용이 없습니당...! (그렇게 치면 cacheTime도 늘리면 되긴 하는데, 사용자가 5분 이상 결과 페이지에 있는 경우가 적을 것 같기도 하고, 5분마다 요청 1번 정도는 괜찮을 듯 해서 우선 냅뒀습니다. 너무 영구적으로 어딘가에 데이터를 저장하는것도 안 좋은 것 같기도 했구... 사실 이 부분은 더 고민이 필요할 것 같긴 합니다)

## 📸 결과물 스크린샷