### PR TITLE
[chat] 채팅 페이지 / TextTop 반응형 구현

### DIFF
--- a/src/components/chat/ChatBody.tsx
+++ b/src/components/chat/ChatBody.tsx
@@ -126,6 +126,10 @@ const StChatWrapper = styled.div`
   min-height: 100vh;
   background-color: ${COLOR.IVORY_1};
   z-index: 1;
+
+  @media screen and (min-width: 1920px) {
+    padding: 0 40rem;
+  }
 `;
 
 const StEmoticonWrapper = styled.div``;
@@ -180,7 +184,7 @@ const StInputQuestion = styled.div`
   display: inline-block;
   position: relative;
   top: -1.2rem;
-  width: auto;
+  width: fit-content;
   height: 100%;
   padding: 0.8rem 1.2rem;
   margin: 1rem 7.3rem 0rem 6.2rem;
@@ -214,10 +218,10 @@ const StPosition = styled.div`
 `;
 
 const StAnswer = styled.div`
-  display: inline-block;
+  display: table;
   position: relative;
   max-width: 23.1rem;
-  width: auto;
+  width: fit-content;
   height: auto;
   padding: 0.8rem 1.2rem;
   margin-bottom: 1.8rem;

--- a/src/components/chat/ChatBody.tsx
+++ b/src/components/chat/ChatBody.tsx
@@ -130,7 +130,7 @@ const StChatWrapper = styled.div`
   @media screen and (min-width: 1920px) {
     padding: 0 40rem;
   }
-  @media screen and (min-width: 744px) {
+  @media screen and (min-width: 766px) {
     padding: 0 3.5rem;
   }
 `;

--- a/src/components/chat/ChatBody.tsx
+++ b/src/components/chat/ChatBody.tsx
@@ -130,6 +130,9 @@ const StChatWrapper = styled.div`
   @media screen and (min-width: 1920px) {
     padding: 0 40rem;
   }
+  @media screen and (min-width: 744px) {
+    padding: 0 3.5rem;
+  }
 `;
 
 const StEmoticonWrapper = styled.div``;

--- a/src/components/chat/ChoiceAnswer.tsx
+++ b/src/components/chat/ChoiceAnswer.tsx
@@ -95,7 +95,7 @@ const StChoiceInput = styled.div`
     margin: 0 -40rem;
     padding: 0 60rem;
   }
-  @media screen and (min-width: 744px) {
+  @media screen and (min-width: 766px) {
     margin: 0 -3.5rem;
   }
 `;

--- a/src/components/chat/ChoiceAnswer.tsx
+++ b/src/components/chat/ChoiceAnswer.tsx
@@ -90,4 +90,9 @@ const StChoiceInput = styled.div`
   background-color: ${COLOR.WHITE_100};
   z-index: 1;
   ${FONT_STYLES.NEXON_R_13};
+
+  @media screen and (min-width: 1920px) {
+    margin: 0 -40rem;
+    padding: 0 60rem;
+  }
 `;

--- a/src/components/chat/ChoiceAnswer.tsx
+++ b/src/components/chat/ChoiceAnswer.tsx
@@ -95,4 +95,7 @@ const StChoiceInput = styled.div`
     margin: 0 -40rem;
     padding: 0 60rem;
   }
+  @media screen and (min-width: 744px) {
+    margin: 0 -3.5rem;
+  }
 `;

--- a/src/components/chat/FirstChoiceAnswer.tsx
+++ b/src/components/chat/FirstChoiceAnswer.tsx
@@ -42,7 +42,7 @@ const StChoiceInput = styled.div`
   @media screen and (min-width: 1920px) {
     margin: 0 -40rem;
   }
-  @media screen and (min-width: 744px) {
+  @media screen and (min-width: 766px) {
     margin: 0 -3.5rem;
   }
 `;

--- a/src/components/chat/FirstChoiceAnswer.tsx
+++ b/src/components/chat/FirstChoiceAnswer.tsx
@@ -42,4 +42,7 @@ const StChoiceInput = styled.div`
   @media screen and (min-width: 1920px) {
     margin: 0 -40rem;
   }
+  @media screen and (min-width: 744px) {
+    margin: 0 -3.5rem;
+  }
 `;

--- a/src/components/chat/FirstChoiceAnswer.tsx
+++ b/src/components/chat/FirstChoiceAnswer.tsx
@@ -38,4 +38,8 @@ const StChoiceInput = styled.div`
   background-color: ${COLOR.WHITE_100};
   gap: 1.6rem;
   z-index: 3;
+
+  @media screen and (min-width: 1920px) {
+    margin: 0 -40rem;
+  }
 `;

--- a/src/components/chat/InputAnswer.tsx
+++ b/src/components/chat/InputAnswer.tsx
@@ -109,13 +109,13 @@ const StSubmitButton = styled.button`
 `;
 
 const StCountTextNumber = styled.div`
+  color: ${COLOR.GRAY_7E};
+  ${FONT_STYLES.PRETENDARD_SB_12};
   @media screen and (max-width: 1920px) {
     position: absolute;
     right: 1.8rem;
     bottom: 0.6rem;
   }
-  color: ${COLOR.GRAY_7E};
-  ${FONT_STYLES.PRETENDARD_SB_12};
 `;
 
 const StForm = styled.form`
@@ -136,14 +136,15 @@ const StForm = styled.form`
       margin: 0rem 1rem;
     }
   }
+
+  @media screen and (min-width: 766px) {
+    margin: 0 -3.5rem;
+    justify-content: center;
+  }
   @media screen and (min-width: 1920px) {
     margin: 0 -40rem;
     justify-content: center;
     padding: 1.5rem 0rem;
-  }
-  @media screen and (min-width: 766px) {
-    margin: 0 -3.5rem;
-    justify-content: center;
   }
 `;
 

--- a/src/components/chat/InputAnswer.tsx
+++ b/src/components/chat/InputAnswer.tsx
@@ -95,26 +95,28 @@ function InputAnswer({ setQuestionIndex, questionIndex, setInput, teamId, setCha
 export default InputAnswer;
 
 const StSubmitButton = styled.button`
-  position: relative;
-  margin-bottom: 1.7rem;
+  /* position: relative; */
+  /* margin-bottom: 1rem; */
   .SubmitButton {
-    position: fixed;
-    bottom: 2.7rem;
-    right: 1.7rem;
+    /* position: fixed; */
+    /* bottom: 2.7rem; */
+    /* right: 1.7rem; */
   }
 `;
 
 const StCountTextNumber = styled.div`
-  position: absolute;
-  right: 1.8rem;
-  bottom: 0.6rem;
+  /* position: absolute; */
+  /* right: 1.8rem; */
+  /* bottom: 0.6rem; */
+  /* margin-bottom: 1rem; */
+
   color: ${COLOR.GRAY_7E};
   ${FONT_STYLES.PRETENDARD_SB_12};
 `;
 
 const StForm = styled.form`
   display: flex;
-
+  justify-content: center;
   align-items: center;
   position: fixed;
   width: 100vw;
@@ -122,20 +124,25 @@ const StForm = styled.form`
   bottom: 0;
   background-color: ${COLOR.WHITE_100};
   z-index: 4;
+  padding: 1.5rem 0rem;
   .buttonLogo {
     position: relative;
     width: 2.4rem;
     height: 4rem;
-    margin: 0 0.8rem 2.5rem 1.6rem;
+    margin-right: 1rem;
+    /* margin: 0 0.8rem 2.5rem 1.6rem; */
+  }
+  @media screen and (min-width: 1920px) {
+    margin: 0 -40rem;
   }
 `;
 
 const StInput = styled.textarea`
   width: 71.9%;
   height: 4rem;
-  bottom: 2.4rem;
+  /* bottom: 2.4rem; */
   padding: 1.2rem 5.2rem 1.2rem 1.4rem;
-  margin: 0.8rem 0 2.5rem 0;
+  /* margin: 0.8rem 0 0rem 0; */
   border: 0.1rem solid ${COLOR.GRAY_EC};
   border-radius: 2.6rem;
   color: ${COLOR.BLACK};

--- a/src/components/chat/InputAnswer.tsx
+++ b/src/components/chat/InputAnswer.tsx
@@ -95,28 +95,31 @@ function InputAnswer({ setQuestionIndex, questionIndex, setInput, teamId, setCha
 export default InputAnswer;
 
 const StSubmitButton = styled.button`
-  /* position: relative; */
-  /* margin-bottom: 1rem; */
+  @media screen and (max-width: 1920px) {
+    position: relative;
+    margin-bottom: 1.7rem;
+  }
   .SubmitButton {
-    /* position: fixed; */
-    /* bottom: 2.7rem; */
-    /* right: 1.7rem; */
+    @media screen and (max-width: 1920px) {
+      position: fixed;
+      bottom: 2.7rem;
+      right: 1.7rem;
+    }
   }
 `;
 
 const StCountTextNumber = styled.div`
-  /* position: absolute; */
-  /* right: 1.8rem; */
-  /* bottom: 0.6rem; */
-  /* margin-bottom: 1rem; */
-
+  @media screen and (max-width: 1920px) {
+    position: absolute;
+    right: 1.8rem;
+    bottom: 0.6rem;
+  }
   color: ${COLOR.GRAY_7E};
   ${FONT_STYLES.PRETENDARD_SB_12};
 `;
 
 const StForm = styled.form`
   display: flex;
-  justify-content: center;
   align-items: center;
   position: fixed;
   width: 100vw;
@@ -124,25 +127,32 @@ const StForm = styled.form`
   bottom: 0;
   background-color: ${COLOR.WHITE_100};
   z-index: 4;
-  padding: 1.5rem 0rem;
   .buttonLogo {
     position: relative;
     width: 2.4rem;
     height: 4rem;
-    margin-right: 1rem;
-    /* margin: 0 0.8rem 2.5rem 1.6rem; */
+    margin: 0 0.8rem 2.5rem 1.6rem;
+    @media screen and (min-width: 1920px) {
+      margin: 0rem 1rem;
+    }
   }
   @media screen and (min-width: 1920px) {
     margin: 0 -40rem;
+    justify-content: center;
+    padding: 1.5rem 0rem;
+  }
+  @media screen and (min-width: 744px) {
+    margin: 0 -3.5rem;
+    justify-content: center;
   }
 `;
 
 const StInput = styled.textarea`
-  width: 71.9%;
+  width: 71%;
   height: 4rem;
-  /* bottom: 2.4rem; */
+  bottom: 2.4rem;
   padding: 1.2rem 5.2rem 1.2rem 1.4rem;
-  /* margin: 0.8rem 0 0rem 0; */
+  margin: 0.8rem 0 2.5rem 0;
   border: 0.1rem solid ${COLOR.GRAY_EC};
   border-radius: 2.6rem;
   color: ${COLOR.BLACK};
@@ -154,5 +164,13 @@ const StInput = styled.textarea`
   ${FONT_STYLES.NEXON_R_16};
   &::placeholder {
     color: ${COLOR.GRAY_7E};
+  }
+  @media screen and (min-width: 744px) {
+    width: 82%;
+  }
+  @media screen and (min-width: 1920px) {
+    width: 104rem;
+    bottom: 0rem;
+    margin: 0rem;
   }
 `;

--- a/src/components/chat/InputAnswer.tsx
+++ b/src/components/chat/InputAnswer.tsx
@@ -141,7 +141,7 @@ const StForm = styled.form`
     justify-content: center;
     padding: 1.5rem 0rem;
   }
-  @media screen and (min-width: 744px) {
+  @media screen and (min-width: 766px) {
     margin: 0 -3.5rem;
     justify-content: center;
   }
@@ -165,7 +165,7 @@ const StInput = styled.textarea`
   &::placeholder {
     color: ${COLOR.GRAY_7E};
   }
-  @media screen and (min-width: 744px) {
+  @media screen and (min-width: 766px) {
     width: 82%;
   }
   @media screen and (min-width: 1920px) {

--- a/src/components/chat/WatchMyResultButton.tsx
+++ b/src/components/chat/WatchMyResultButton.tsx
@@ -35,4 +35,8 @@ const StWatchMyResultButton = styled.div`
     margin: 0 -40rem;
     padding: 0 60rem;
   }
+
+  @media screen and (min-width: 744px) {
+    margin: 0 -3.5rem;
+  }
 `;

--- a/src/components/chat/WatchMyResultButton.tsx
+++ b/src/components/chat/WatchMyResultButton.tsx
@@ -31,12 +31,12 @@ const StWatchMyResultButton = styled.div`
   z-index: 1;
   background-color: ${COLOR.WHITE_100};
 
+  @media screen and (min-width: 766px) {
+    margin: 0 -3.5rem;
+  }
+
   @media screen and (min-width: 1920px) {
     margin: 0 -40rem;
     padding: 0 60rem;
-  }
-
-  @media screen and (min-width: 766px) {
-    margin: 0 -3.5rem;
   }
 `;

--- a/src/components/chat/WatchMyResultButton.tsx
+++ b/src/components/chat/WatchMyResultButton.tsx
@@ -36,7 +36,7 @@ const StWatchMyResultButton = styled.div`
     padding: 0 60rem;
   }
 
-  @media screen and (min-width: 744px) {
+  @media screen and (min-width: 766px) {
     margin: 0 -3.5rem;
   }
 `;

--- a/src/components/chat/WatchMyResultButton.tsx
+++ b/src/components/chat/WatchMyResultButton.tsx
@@ -30,4 +30,9 @@ const StWatchMyResultButton = styled.div`
   bottom: 0;
   z-index: 1;
   background-color: ${COLOR.WHITE_100};
+
+  @media screen and (min-width: 1920px) {
+    margin: 0 -40rem;
+    padding: 0 60rem;
+  }
 `;

--- a/src/components/common/TextTop.tsx
+++ b/src/components/common/TextTop.tsx
@@ -1,13 +1,21 @@
 import styled from 'styled-components';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import { COLOR } from '@src/styles/color';
-
+import ImageDiv from './ImageDiv';
+import { imgTopLogo } from 'public/assets/images';
 interface TextTopProps {
   text: string;
 }
 
 function TextTop({ text }: TextTopProps) {
-  return <StTextTop>{text}</StTextTop>;
+  return (
+    <>
+      <StTextTop>
+        <ImageDiv src={imgTopLogo} alt="T.time" className="imgTopLogo" fill={true} />
+        {text}
+      </StTextTop>
+    </>
+  );
 }
 
 export default TextTop;
@@ -17,7 +25,7 @@ const StTextTop = styled.div`
   justify-content: center;
   align-items: center;
   position: fixed;
-  flex-direction: column;
+  flex-direction: row;
   min-width: 39rem;
   width: 100vw;
   height: 5.8rem;
@@ -25,4 +33,17 @@ const StTextTop = styled.div`
   backdrop-filter: blur(0.5rem);
   color: ${COLOR.BLACK};
   ${FONT_STYLES.PRETENDARD_B_20}
+
+  .imgTopLogo {
+    @media screen and (max-width: 766px) {
+      display: hidden;
+      width: 0;
+      height: 0;
+    }
+    position: absolute;
+    left: 0;
+    width: 5.8rem;
+    height: 3rem;
+    margin-left: 4rem;
+  }
 `;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #176 

## 📋 구현 기능 명세
- [x] 채팅 페이지 반응형 구현
- [x] TextTop 반응형 구현

## 📌 PR Point
- 1920일 때랑 태블릿, 핸드폰일 때 인풋창 디자인이 묘하게 바뀌는 부분들이 있어서 고런 부분들 다 반영해서 수정했숩니다
- 신기한걸 하나 발견했어요 말풍선을 width: content-fit으로 했을 땐 영어로 했을 때는 안 먹히더라구요
<img width="959" alt="스크린샷 2023-06-07 오후 10 48 13" src="https://github.com/Antititi-time/T.TIME_CLIENT/assets/87795291/35380ba4-4435-4ad1-9011-a6507c434bdb">

이렇게... 그래서 검색해봤더니 display:table로 하면 영어도 먹힌다길래 변경했습니다 테이블은 첨 듣는데 신기하더라구용
- 여하튼 혼자 저렇게 100자 넘는 영어, 한글도 입력해보고 반응형도 계속 변경해보고 인풋, 초이스, 결과버튼 등 다 최대한 많이 꼼꼼히 확인했으나... qa하다보면 또 발견될 부분이 있을 수도..있을 거 같아유...


## 📸 결과물 스크린샷
![채팅 초이스 반응형](https://github.com/Antititi-time/T.TIME_CLIENT/assets/87795291/c3082639-f1e5-4db9-a304-05f43f3b99f1)
![개인결과 반응형](https://github.com/Antititi-time/T.TIME_CLIENT/assets/87795291/6d2db86b-88ce-4c82-9a91-0da0bf2beb85)
![채팅 인풋 반응형](https://github.com/Antititi-time/T.TIME_CLIENT/assets/87795291/59798b6c-4201-4c96-8b8e-c9c1fdb54612)
