### PR TITLE
[Invite] 초대장 작성 및 확인 페이지 반응형 구현

### DIFF
--- a/src/components/invite/TeamInput.tsx
+++ b/src/components/invite/TeamInput.tsx
@@ -67,8 +67,6 @@ const StInput = styled.input`
     transform: none;
   }
   width: 121.428571429%;
-  /* width: 29.4rem;
-  height: 4.8rem; */
   padding-top: 1.82142856rem;
   padding-bottom: 2.06428571rem;
   padding-left: 1.45714285rem;

--- a/src/components/invite/TeamInput.tsx
+++ b/src/components/invite/TeamInput.tsx
@@ -39,6 +39,10 @@ const StTeamInput = styled.div`
   gap: 0.8rem;
   width: 29.4rem;
   height: 7.9rem;
+  @media screen and (min-width: 766px) {
+    width: auto;
+    height: auto;
+  }
 `;
 const StLabelWrapper = styled.div`
   display: flex;
@@ -47,12 +51,24 @@ const StLabelWrapper = styled.div`
 `;
 
 const StText = styled.p`
+  @media screen and (min-width: 766px) {
+    ${FONT_STYLES.NEXON_B_24}
+  }
   color: ${COLOR.BLUE_TEXT};
   ${FONT_STYLES.NEXON_B_16};
 `;
 
 const StInput = styled.input`
+  @media screen and (min-width: 766px) {
+    width: 41.6rem;
+    height: 5.4rem;
+    padding-top: unset;
+    padding-bottom: unset;
+    transform: none;
+  }
   width: 121.428571429%;
+  /* width: 29.4rem;
+  height: 4.8rem; */
   padding-top: 1.82142856rem;
   padding-bottom: 2.06428571rem;
   padding-left: 1.45714285rem;

--- a/src/pages/invite/[teamId].tsx
+++ b/src/pages/invite/[teamId].tsx
@@ -142,7 +142,7 @@ const StInvitationContainer = styled.article`
       width: 10.3rem;
     }
   }
-  @media screen and (min-width: 766px) and (max-width: 1919px) {
+  @media screen and (min-width: 766px) and (max-width: 1920px) {
     height: 70vh;
     width: 89vw;
     gap: 4rem;
@@ -248,7 +248,7 @@ const StBtnContainer = styled.div`
     }
   }
 
-  @media screen and (max-width: 1919px) {
+  @media screen and (max-width: 1920px) {
     gap: 2rem;
   }
 `;

--- a/src/pages/invite/[teamId].tsx
+++ b/src/pages/invite/[teamId].tsx
@@ -47,36 +47,48 @@ function ConfirmInvite({ teamId, teamName }: ConfirmInviteProps) {
       <TextTop text={'초대장 만들기'} />
       <ToolTipIcon top={5.8} />
       <StInvitationContainer>
-        <ImageDiv src={imgInvitation} alt="초대장이미지" className="invitationImg"></ImageDiv>
-        <StTeamName>&apos;{teamName}&apos;</StTeamName>
-        <StRowContainer>
-          <ImageDiv src={imgJoinLogo} alt="T.time_logo" className="imgCenturyGothicLogo" fill></ImageDiv>
-          <StInviteComment>에 초대합니다</StInviteComment>
-        </StRowContainer>
-        <StListContainer>
-          <StList>총 {router.query.teamNum}명</StList>
-          <StList>질문 개수: 10개</StList>
-          <StList>예상 소요시간: 약 10분 이내</StList>
-        </StListContainer>
+        <ImageDiv src={imgInvitation} alt="초대장이미지" className="invitationImg" />
+        <StLine />
+        <div>
+          <div>
+            <StTeamName>&apos;{teamName}&apos;</StTeamName>
+            <StRowContainer>
+              <ImageDiv src={imgJoinLogo} alt="T.time_logo" className="imgCenturyGothicLogo" fill></ImageDiv>
+              <StInviteComment>에 초대합니다.</StInviteComment>
+            </StRowContainer>
+            <StListContainer>
+              <StList>총 {router.query.teamNum}명</StList>
+              <StList>질문 개수: 10개</StList>
+              <StList>예상 소요시간: 약 10분 이내</StList>
+            </StListContainer>
+          </div>
+        </div>
       </StInvitationContainer>
-      {isConfirmed ? (
-        <StBtnWrapper onClick={() => setModalState(true)}>
-          <BottomButton width={28.2} color={COLOR.BLUE_1} text={'초대장 공유하기'} />
-        </StBtnWrapper>
-      ) : (
-        <StMessage>위 정보로 티타임 초대장을 만드시겠습니까?</StMessage>
-      )}
-      {!isConfirmed ? (
-        <StConfirmBtn onClick={() => setIsconfirmed(true)}>
-          <BottomButton width={28.2} color={COLOR.ORANGE_1} text={isConfirmed ? '티타임 참여하기' : '확인'} />
-        </StConfirmBtn>
-      ) : (
-        <Link href={`/join/${router.query.teamId}`}>
-          <StConfirmBtn>
+      <StBtnContainer className={isConfirmed ? 'flex-container' : ''}>
+        {isConfirmed ? (
+          <BottomButton
+            width={28.2}
+            color={COLOR.BLUE_1}
+            text={'초대장 공유하기'}
+            handler={() => setModalState(true)}
+          />
+        ) : (
+          <StMessage>위 정보로 티타임 초대장을 만드시겠습니까?</StMessage>
+        )}
+
+        {!isConfirmed ? (
+          <BottomButton
+            width={28.2}
+            color={COLOR.ORANGE_1}
+            text={isConfirmed ? '티타임 참여하기' : '확인'}
+            handler={() => setIsconfirmed(true)}
+          />
+        ) : (
+          <Link href={`/join/${router.query.teamId}`}>
             <BottomButton width={28.2} color={COLOR.ORANGE_1} text={isConfirmed ? '티타임 참여하기' : '확인'} />
-          </StConfirmBtn>
-        </Link>
-      )}
+          </Link>
+        )}
+      </StBtnContainer>
     </StConfirmInvite>
   );
 }
@@ -99,6 +111,11 @@ const StConfirmInvite = styled.div`
     width: 12.8rem;
     height: 12.8rem;
     margin-bottom: 1rem;
+
+    @media screen and (min-width: 766px) {
+      width: 23vh;
+      height: 23vh;
+    }
   }
 `;
 
@@ -120,6 +137,44 @@ const StInvitationContainer = styled.article`
     width: 5.2rem;
     height: 3.2rem;
     bottom: 0.4rem;
+    @media screen and (min-width: 766px) {
+      height: 6.4rem;
+      width: 10.3rem;
+    }
+  }
+  @media screen and (min-width: 766px) and (max-width: 1919px) {
+    height: 70vh;
+    width: 89vw;
+    gap: 4rem;
+  }
+
+  @media screen and (min-width: 1920px) {
+    flex-direction: row;
+    gap: unset;
+    width: 62.5vw;
+    max-width: 1200px;
+    height: 71vh;
+    max-height: 727px;
+    padding: 0;
+    & > div:first-child {
+      flex-grow: 1;
+      text-align: center;
+    }
+    & > div:last-child {
+      flex-grow: 1.34;
+      display: flex;
+      justify-content: center;
+    }
+  }
+`;
+
+const StLine = styled.div`
+  display: none;
+  height: calc(100% - 74px);
+  width: 0.2rem;
+  background-color: ${COLOR.IVORY_3};
+  @media screen and (min-width: 1920px) {
+    display: block;
   }
 `;
 
@@ -127,6 +182,9 @@ const StTeamName = styled.p`
   color: ${COLOR.BLUE_TEXT};
   ${FONT_STYLES.NEXON_B_16};
   line-height: 2.56rem;
+  @media screen and (min-width: 766px) {
+    ${FONT_STYLES.NEXON_B_24}
+  }
 `;
 
 const StRowContainer = styled.div`
@@ -137,11 +195,17 @@ const StRowContainer = styled.div`
 const StInviteComment = styled.p`
   color: ${COLOR.ORANGE_TEXT};
   ${FONT_STYLES.NEXON_B_20};
+  @media screen and (min-width: 766px) {
+    font-size: 3.2rem; //새로운 font
+  }
 `;
 
 const StListContainer = styled.ol`
   list-style-type: disc;
   margin-top: 2rem;
+  @media screen and (min-width: 766px) {
+    margin-top: 4.6rem;
+  }
 `;
 
 const StList = styled.li`
@@ -150,20 +214,41 @@ const StList = styled.li`
   &:not(:last-child) {
     margin-bottom: 1.2rem;
   }
+  @media screen and (min-width: 766px) {
+    ${FONT_STYLES.NEXON_R_24}
+  }
 `;
 
 const StMessage = styled.p`
   margin-top: 7.1rem;
   color: ${COLOR.GRAY_7E};
   ${FONT_STYLES.NEXON_R_14};
+
+  @media screen and (min-width: 766px) {
+    margin-top: auto;
+  }
 `;
 
-const StBtnWrapper = styled.div`
-  margin-top: 3.9rem;
-  cursor: pointer;
-`;
+const StBtnContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  align-items: center;
+  gap: 1.8rem;
 
-const StConfirmBtn = styled.div`
-  margin-top: 1.8rem;
-  cursor: pointer;
+  &.flex-container {
+    flex-direction: row;
+    margin-top: 3.9rem;
+    @media screen and (max-width: 765px) {
+      flex-direction: column;
+    }
+    @media screen and (min-width: 766px) {
+      align-items: flex-end;
+      margin-top: 0;
+    }
+  }
+
+  @media screen and (max-width: 1919px) {
+    gap: 2rem;
+  }
 `;

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -97,6 +97,12 @@ const StInvite = styled.div`
   background-color: ${COLOR.IVORY_1};
   text-align: center;
   .letterImg img {
+    @media screen and (min-width: 766px) {
+      width: 25vh;
+      height: 25vh;
+      margin-top: 15rem;
+      margin-bottom: 8rem;
+    }
     width: 16.8rem;
     height: 16.8rem;
     margin-top: 9rem;

--- a/src/styles/fontStyle.ts
+++ b/src/styles/fontStyle.ts
@@ -111,10 +111,12 @@ export const FONT_STYLES = {
   NEXON_R_14: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 14, weight: 'R', height: 16 }),
   NEXON_R_16: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 16, weight: 'R', height: 18 }),
   NEXON_R_22: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 22, weight: 'R', height: 30.8 }),
+  NEXON_R_24: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 24, weight: 'R', height: 36 }),
   NEXON_OB_22: FONT({ font: 'NEXON Lv1 Gothic OTF', size: 22, weight: 'B', height: 30.8 }),
   NEXON_B_12: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 12, weight: 'B', height: 14 }),
   NEXON_B_14: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 14, weight: 'B', height: 16 }),
   NEXON_B_16: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 16, weight: 'B', height: 14 }),
   NEXON_B_20: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 20, weight: 'B', height: 23 }),
   NEXON_B_22: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 22, weight: 'B', height: 25 }),
+  NEXON_B_24: FONT({ font: 'NEXON Lv1 Gothic Bold', size: 24, weight: 'B', height: 36 }),
 };


### PR DESCRIPTION
## 🚩 관련 이슈
- close #i171

## 📋 구현 기능 명세
- [x] 초대장 확인 페이지 태블릿 뷰 구현
- [x] 초대장 확인 페이지 데스크탑 뷰 구현
- [x] 초대장 작성 페이지 태블릿 뷰 구현
- [x] 초대장 작성 페이지 데스크탑 뷰 구현

## 📌 PR Point

- 새로 변형된 부분이 있어서 UI에 새로운 element 추가하거나, 마진 값, 크기 등을 변경하였습니다.
- 이미지가 상당히 커 이미지의 비율을 vh에 맞게 조정하였습니다.  



## 📸 결과물 스크린샷

태블릿 뷰

<img width="1440" alt="스크린샷 2023-06-09 오전 2 48 38" src="https://github.com/Antititi-time/T.TIME_CLIENT/assets/92535912/7c8cf7df-4109-4a8a-8853-6a3bfe532a0c">

<img width="1440" alt="스크린샷 2023-06-09 오전 2 48 29" src="https://github.com/Antititi-time/T.TIME_CLIENT/assets/92535912/c67bf7a0-5131-41b5-b6c2-3010f0d2ce97">

데스크탑 뷰

<img width="548" alt="스크린샷 2023-06-09 오전 2 49 10" src="https://github.com/Antititi-time/T.TIME_CLIENT/assets/92535912/c14895b2-e4cd-4644-b934-4bed997fcbad">

