### PR TITLE
[Fix] unfinished 에서생기는 무한 뒤로가기 오류 해결

### DIFF
--- a/src/pages/myResult/[teamId]/[userId].tsx
+++ b/src/pages/myResult/[teamId]/[userId].tsx
@@ -37,11 +37,11 @@ function MyResult({ userId, teamId, myResultData }: userIdType) {
   const [resultData, setResultData] = useState<UserData>();
   const [resultCharacter, setResultCharacter] = useState(0);
   const [isVisitor, setIsVisitor] = useState(false);
-  const { isReady, push } = useRouter();
+  const { isReady, replace } = useRouter();
 
   const [modalState, setModalState] = useState(false);
   useEffect(() => {
-    if (myResultData.result.length < 5) push('/unfinished');
+    if (myResultData.result.length < 5) replace('/unfinished');
     setResultData(myResultData);
     const inputData = setConstantIndex(myResultData?.result[4]?.questionType);
     setResultCharacter(inputData);


### PR DESCRIPTION
## 🚩 관련 이슈
  - close #209 

## 📋 구현 기능 명세
- [x] `/unfinished`에서 생기는 뒤로가기 버튼 오류 해결

## 📌 PR Point
- 기존에 결과페이지에 들어가면 useeffect 안에서 결과를 확인하고, 결과가 없을 경우 `router.push`를 이용해 `/unfinished`로 가게끔 돼있었는데, 그렇게 되면 뒤로가기를 눌러도 다시 결과페이지로 가고 결과페이지에서 또 useeffect로 `router.push` 실행, 또 다시 `/unfinished`로 이동.. 이런 루트가 되어 무한 뒤로가기 현상이 발생하고 있었습니다.
- 그래서 `push`가 아닌 `replace`로 변경해주었습니다. `replace`로 변경하면 애초에 내 결과 페이지로 들어가지 않고 라우터가 대체되는거라 뒤로가기를 누르면 결과페이지가 아닌 결과목록페이지로 가게 됩니다.


## 📸 결과물 스크린샷